### PR TITLE
[chore] remove TODOs and add cluster spec validators

### DIFF
--- a/redpanda/resources/acl/resource_acl.go
+++ b/redpanda/resources/acl/resource_acl.go
@@ -76,7 +76,6 @@ func (*ACL) Schema(_ context.Context, _ resource.SchemaRequest, response *resour
 func resourceACLSchema() schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{
-			// TODO: needs String validators.
 			"resource_type": schema.StringAttribute{
 				Required:      true,
 				Description:   "The type of the resource (Topic, Group, etc...) this ACL shall target",

--- a/redpanda/resources/cluster/resource_cluster_test.go
+++ b/redpanda/resources/cluster/resource_cluster_test.go
@@ -52,7 +52,7 @@ func TestGenerateClusterRequest(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GenerateClusterRequest(tt.args.model); !reflect.DeepEqual(got, tt.want) {
+			if got, _ := GenerateClusterRequest(tt.args.model); !reflect.DeepEqual(got, tt.want) {
 				fmt.Println("got")
 				spew.Dump(got)
 				fmt.Println("want")

--- a/redpanda/utils/utils.go
+++ b/redpanda/utils/utils.go
@@ -44,19 +44,16 @@ func IsNotFound(err error) bool {
 	return false
 }
 
-// TODO check more to see if the client handles this
-
 // StringToCloudProvider returns the cloudv1beta1's CloudProvider code based on
 // the input string.
-func StringToCloudProvider(p string) cloudv1beta1.CloudProvider {
+func StringToCloudProvider(p string) (cloudv1beta1.CloudProvider, error) {
 	switch strings.ToLower(p) {
 	case "aws":
-		return cloudv1beta1.CloudProvider_CLOUD_PROVIDER_AWS
+		return cloudv1beta1.CloudProvider_CLOUD_PROVIDER_AWS, nil
 	case "gcp":
-		return cloudv1beta1.CloudProvider_CLOUD_PROVIDER_GCP
+		return cloudv1beta1.CloudProvider_CLOUD_PROVIDER_GCP, nil
 	default:
-		return cloudv1beta1.CloudProvider_CLOUD_PROVIDER_UNSPECIFIED
-		// TODO should we error here?
+		return cloudv1beta1.CloudProvider_CLOUD_PROVIDER_UNSPECIFIED, fmt.Errorf("provider %q not supported", p)
 	}
 }
 
@@ -70,21 +67,19 @@ func CloudProviderToString(provider cloudv1beta1.CloudProvider) string {
 		return "gcp"
 	default:
 		return providerUnspecified
-		// TODO should we error here?
 	}
 }
 
 // StringToClusterType returns the cloudv1beta1's Cluster_Type code based on
 // the input string.
-func StringToClusterType(p string) cloudv1beta1.Cluster_Type {
+func StringToClusterType(p string) (cloudv1beta1.Cluster_Type, error) {
 	switch strings.ToLower(p) {
 	case "dedicated":
-		return cloudv1beta1.Cluster_TYPE_DEDICATED
+		return cloudv1beta1.Cluster_TYPE_DEDICATED, nil
 	case "cloud":
-		return cloudv1beta1.Cluster_TYPE_BYOC
+		return cloudv1beta1.Cluster_TYPE_BYOC, nil
 	default:
-		return cloudv1beta1.Cluster_TYPE_UNSPECIFIED
-		// TODO should we error here?
+		return cloudv1beta1.Cluster_TYPE_UNSPECIFIED, fmt.Errorf("cluster type %q not supported", p)
 	}
 }
 
@@ -98,7 +93,6 @@ func ClusterTypeToString(provider cloudv1beta1.Cluster_Type) string {
 		return "cloud"
 	default:
 		return providerUnspecified
-		// TODO should we error here?
 	}
 }
 


### PR DESCRIPTION
This removes TODOs that are now issues in GH and also adds error checks when either the cluster type or cloud provider is invalid.

I tried sending requests to the control plane API and they fail if we don't specify a valid type/provider:
```
- network.cloud_provider: value must not be in list [0] [enum.not_in]
- network.cluster_type: network.cluster_type must be either TYPE_DEDICATED or TYPE_BYOC [field=network.cluster_type network.cluster_type.allowed_values]
```

So we better fail early here.