### PR TITLE
[bugfix] allow cluster updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @gene-redpanda
-* @r-vasquez
+* @gene-redpanda @r-vasquez

--- a/redpanda/resources/acl/resource_acl.go
+++ b/redpanda/resources/acl/resource_acl.go
@@ -118,7 +118,8 @@ func resourceACLSchema() schema.Schema {
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"id": schema.StringAttribute{
-				Computed: true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 		},
 	}

--- a/redpanda/resources/namespace/resource_namespace.go
+++ b/redpanda/resources/namespace/resource_namespace.go
@@ -95,8 +95,9 @@ func resourceNamespaceSchema() schema.Schema {
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"id": schema.StringAttribute{
-				Computed:    true,
-				Description: "UUID of the namespace",
+				Computed:      true,
+				Description:   "UUID of the namespace",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 		},
 		Description: "A Redpanda Cloud namespace",

--- a/redpanda/resources/user/resource_user.go
+++ b/redpanda/resources/user/resource_user.go
@@ -108,7 +108,8 @@ func resourceUserSchema() schema.Schema {
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"id": schema.StringAttribute{
-				Computed: true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 		},
 	}


### PR DESCRIPTION
This commit fixes a bug where the user was not able to update `allow_deletion` in the cluster resource.

When updating `Computed` attributes Terraform will treat them as 'changing' attributes and trigger an error. To solve this we add the plan modifier as recommended by Terraform:

>  Use the [resource.UseStateForUnknown() attribute plan modifier](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#UseStateForUnknown) for Computed attributes that are known to not change during resource updates. This will enhance the Terraform plan to not show => (known after apply) differences.

Also implementing `Update` in the cluster resource as a passthrough from plan -> state due to:

```
│ Error: Provider produced inconsistent result after apply
│ 
│ When applying changes to redpanda_cluster.test, provider "provider[\"registry.terraform.io/redpanda-data/redpanda\"]" produced an unexpected new value: .allow_deletion: was cty.False, but now cty.True.
│ 
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
```
Fixes #21