### PR TITLE
[bug] Remove unsupported properties from provider config docs

### DIFF
--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -48,8 +48,18 @@ provider "redpanda" {}
 variable "cluster_id" {
   default = ""
 }
+
 data "redpanda_cluster" "test" {
   id = var.cluster_id
+}
+
+resource "redpanda_topic" "test" {
+  name               = var.topic_name
+  partition_count    = var.partition_count
+  replication_factor = var.replication_factor
+  cluster_api_url    = data.redpanda_cluster.test.cluster_api_url
+  allow_deletion     = true
+  configuration      = var.topic_config
 }
 
 resource "redpanda_user" "test" {
@@ -68,6 +78,14 @@ resource "redpanda_acl" "test" {
   operation             = "ALTER"
   permission_type       = "ALLOW"
   cluster_api_url       = data.redpanda_cluster.test.cluster_api_url
+}
+
+variable "topic_config" {
+  default = {
+    "cleanup.policy"   = "compact"
+    "flush.ms"         = 100
+    "compression.type" = "snappy"
+  }
 }
 
 variable "user_name" {

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,11 +37,8 @@ terraform {
 }
 
 provider "redpanda" {
-  client_id      = "your_client_id"
-  client_secret  = "your_client_secret"
-  cloud_provider = "aws"
-  region         = "us-west-2"
-  zones          = ["us-west-2a", "us-west-2b"]
+  client_id     = "your_client_id"
+  client_secret = "your_client_secret"
 }
 ```
 
@@ -75,7 +72,7 @@ resource "redpanda_cluster" "test" {
   throughput_tier = var.throughput_tier
   zones           = var.zones
   allow_deletion  = true
-  tags            = {
+  tags = {
     // not actually used as API does not consume it yet but we keep it in state for when it does
     "key" = "value"
   }
@@ -84,6 +81,7 @@ resource "redpanda_cluster" "test" {
 variable "namespace_name" {
   default = "testname"
 }
+
 variable "network_name" {
   default = "testname"
 }
@@ -138,16 +136,19 @@ resource "redpanda_cluster" "test" {
   throughput_tier = var.throughput_tier
   zones           = var.zones
   allow_deletion  = true
-  tags            = {
+  tags = {
     "key" = "value"
   }
 }
+
 variable "cluster_name" {
   default = ""
 }
+
 variable "namespace_name" {
   default = ""
 }
+
 variable "network_name" {
   default = ""
 }
@@ -177,8 +178,18 @@ provider "redpanda" {}
 variable "cluster_id" {
   default = ""
 }
+
 data "redpanda_cluster" "test" {
   id = var.cluster_id
+}
+
+resource "redpanda_topic" "test" {
+  name               = var.topic_name
+  partition_count    = var.partition_count
+  replication_factor = var.replication_factor
+  cluster_api_url    = data.redpanda_cluster.test.cluster_api_url
+  allow_deletion     = true
+  configuration      = var.topic_config
 }
 
 resource "redpanda_user" "test" {
@@ -197,6 +208,14 @@ resource "redpanda_acl" "test" {
   operation             = "ALTER"
   permission_type       = "ALLOW"
   cluster_api_url       = data.redpanda_cluster.test.cluster_api_url
+}
+
+variable "topic_config" {
+  default = {
+    "cleanup.policy"   = "compact"
+    "flush.ms"         = 100
+    "compression.type" = "snappy"
+  }
 }
 
 variable "user_name" {

--- a/docs/resources/acl.md
+++ b/docs/resources/acl.md
@@ -59,7 +59,7 @@ resource "redpanda_cluster" "test" {
   throughput_tier = var.throughput_tier
   zones           = var.zones
   allow_deletion  = true
-  tags            = {
+  tags = {
     // not actually used as API does not consume it yet but we keep it in state for when it does
     "key" = "value"
   }

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -69,7 +69,7 @@ resource "redpanda_cluster" "test" {
   throughput_tier = var.throughput_tier
   zones           = var.zones
   allow_deletion  = true
-  tags            = {
+  tags = {
     // not actually used as API does not consume it yet but we keep it in state for when it does
     "key" = "value"
   }
@@ -78,6 +78,7 @@ resource "redpanda_cluster" "test" {
 variable "namespace_name" {
   default = "testname"
 }
+
 variable "network_name" {
   default = "testname"
 }
@@ -132,16 +133,19 @@ resource "redpanda_cluster" "test" {
   throughput_tier = var.throughput_tier
   zones           = var.zones
   allow_deletion  = true
-  tags            = {
+  tags = {
     "key" = "value"
   }
 }
+
 variable "cluster_name" {
   default = ""
 }
+
 variable "namespace_name" {
   default = ""
 }
+
 variable "network_name" {
   default = ""
 }
@@ -178,8 +182,18 @@ provider "redpanda" {}
 variable "cluster_id" {
   default = ""
 }
+
 data "redpanda_cluster" "test" {
   id = var.cluster_id
+}
+
+resource "redpanda_topic" "test" {
+  name               = var.topic_name
+  partition_count    = var.partition_count
+  replication_factor = var.replication_factor
+  cluster_api_url    = data.redpanda_cluster.test.cluster_api_url
+  allow_deletion     = true
+  configuration      = var.topic_config
 }
 
 resource "redpanda_user" "test" {
@@ -198,6 +212,14 @@ resource "redpanda_acl" "test" {
   operation             = "ALTER"
   permission_type       = "ALLOW"
   cluster_api_url       = data.redpanda_cluster.test.cluster_api_url
+}
+
+variable "topic_config" {
+  default = {
+    "cleanup.policy"   = "compact"
+    "flush.ms"         = 100
+    "compression.type" = "snappy"
+  }
 }
 
 variable "user_name" {

--- a/docs/resources/topic.md
+++ b/docs/resources/topic.md
@@ -60,7 +60,7 @@ resource "redpanda_cluster" "test" {
   throughput_tier = var.throughput_tier
   zones           = var.zones
   allow_deletion  = true
-  tags            = {
+  tags = {
     // not actually used as API does not consume it yet but we keep it in state for when it does
     "key" = "value"
   }

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -58,7 +58,7 @@ resource "redpanda_cluster" "test" {
   throughput_tier = var.throughput_tier
   zones           = var.zones
   allow_deletion  = true
-  tags            = {
+  tags = {
     // not actually used as API does not consume it yet but we keep it in state for when it does
     "key" = "value"
   }

--- a/examples/cluster/aws/main.tf
+++ b/examples/cluster/aws/main.tf
@@ -25,7 +25,7 @@ resource "redpanda_cluster" "test" {
   throughput_tier = var.throughput_tier
   zones           = var.zones
   allow_deletion  = true
-  tags            = {
+  tags = {
     // not actually used as API does not consume it yet but we keep it in state for when it does
     "key" = "value"
   }
@@ -34,6 +34,7 @@ resource "redpanda_cluster" "test" {
 variable "namespace_name" {
   default = "testname"
 }
+
 variable "network_name" {
   default = "testname"
 }

--- a/examples/cluster/gcp/main.tf
+++ b/examples/cluster/gcp/main.tf
@@ -24,16 +24,19 @@ resource "redpanda_cluster" "test" {
   throughput_tier = var.throughput_tier
   zones           = var.zones
   allow_deletion  = true
-  tags            = {
+  tags = {
     "key" = "value"
   }
 }
+
 variable "cluster_name" {
   default = ""
 }
+
 variable "namespace_name" {
   default = ""
 }
+
 variable "network_name" {
   default = ""
 }

--- a/examples/datasource/main.tf
+++ b/examples/datasource/main.tf
@@ -3,6 +3,7 @@ provider "redpanda" {}
 variable "cluster_id" {
   default = ""
 }
+
 data "redpanda_cluster" "test" {
   id = var.cluster_id
 }
@@ -35,12 +36,13 @@ resource "redpanda_acl" "test" {
 }
 
 variable "topic_config" {
-    default = {
-      "cleanup.policy"   = "compact"
-      "flush.ms"         = 100
-      "compression.type" = "snappy"
-    }
+  default = {
+    "cleanup.policy"   = "compact"
+    "flush.ms"         = 100
+    "compression.type" = "snappy"
+  }
 }
+
 variable "user_name" {
   default = "test-username"
 }

--- a/examples/provider.tf
+++ b/examples/provider.tf
@@ -8,9 +8,6 @@ terraform {
 }
 
 provider "redpanda" {
-  client_id      = "your_client_id"
-  client_secret  = "your_client_secret"
-  cloud_provider = "aws"
-  region         = "us-west-2"
-  zones          = ["us-west-2a", "us-west-2b"]
+  client_id     = "your_client_id"
+  client_secret = "your_client_secret"
 }

--- a/examples/user-acl-topic/main.tf
+++ b/examples/user-acl-topic/main.tf
@@ -25,7 +25,7 @@ resource "redpanda_cluster" "test" {
   throughput_tier = var.throughput_tier
   zones           = var.zones
   allow_deletion  = true
-  tags            = {
+  tags = {
     // not actually used as API does not consume it yet but we keep it in state for when it does
     "key" = "value"
   }


### PR DESCRIPTION
Provider, region, and zones is not yet supported
to be configured at the provider level, instead
it should be configured in network/cluster.

This commit also runs terraform fmt in all .tf files