### PR TITLE
[bug] Remove unsupported properties from provider config docs

### DIFF
--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -48,6 +48,7 @@ provider "redpanda" {}
 variable "cluster_id" {
   default = ""
 }
+
 data "redpanda_cluster" "test" {
   id = var.cluster_id
 }
@@ -86,6 +87,7 @@ variable "topic_config" {
     "compression.type" = "snappy"
   }
 }
+
 variable "user_name" {
   default = "test-username"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,9 +39,6 @@ terraform {
 provider "redpanda" {
   client_id      = "your_client_id"
   client_secret  = "your_client_secret"
-  cloud_provider = "aws"
-  region         = "us-west-2"
-  zones          = ["us-west-2a", "us-west-2b"]
 }
 ```
 
@@ -63,7 +60,6 @@ resource "redpanda_network" "test" {
   cidr_block        = "10.0.0.0/20"
 }
 
-
 resource "redpanda_cluster" "test" {
   name              = var.cluster_name
   resource_group_id = redpanda_resource_group.test.id
@@ -84,6 +80,7 @@ resource "redpanda_cluster" "test" {
 variable "resource_group_name" {
   default = "testname"
 }
+
 variable "network_name" {
   default = "testname"
 }
@@ -142,12 +139,15 @@ resource "redpanda_cluster" "test" {
     "key" = "value"
   }
 }
+
 variable "cluster_name" {
   default = ""
 }
+
 variable "resource_group_name" {
   default = ""
 }
+
 variable "network_name" {
   default = ""
 }
@@ -177,6 +177,7 @@ provider "redpanda" {}
 variable "cluster_id" {
   default = ""
 }
+
 data "redpanda_cluster" "test" {
   id = var.cluster_id
 }
@@ -215,6 +216,7 @@ variable "topic_config" {
     "compression.type" = "snappy"
   }
 }
+
 variable "user_name" {
   default = "test-username"
 }

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -57,7 +57,6 @@ resource "redpanda_network" "test" {
   cidr_block        = "10.0.0.0/20"
 }
 
-
 resource "redpanda_cluster" "test" {
   name              = var.cluster_name
   resource_group_id = redpanda_resource_group.test.id
@@ -78,6 +77,7 @@ resource "redpanda_cluster" "test" {
 variable "resource_group_name" {
   default = "testname"
 }
+
 variable "network_name" {
   default = "testname"
 }
@@ -136,12 +136,15 @@ resource "redpanda_cluster" "test" {
     "key" = "value"
   }
 }
+
 variable "cluster_name" {
   default = ""
 }
+
 variable "resource_group_name" {
   default = ""
 }
+
 variable "network_name" {
   default = ""
 }
@@ -178,6 +181,7 @@ provider "redpanda" {}
 variable "cluster_id" {
   default = ""
 }
+
 data "redpanda_cluster" "test" {
   id = var.cluster_id
 }
@@ -216,6 +220,7 @@ variable "topic_config" {
     "compression.type" = "snappy"
   }
 }
+
 variable "user_name" {
   default = "test-username"
 }

--- a/examples/cluster/aws/main.tf
+++ b/examples/cluster/aws/main.tf
@@ -13,7 +13,6 @@ resource "redpanda_network" "test" {
   cidr_block        = "10.0.0.0/20"
 }
 
-
 resource "redpanda_cluster" "test" {
   name              = var.cluster_name
   resource_group_id = redpanda_resource_group.test.id
@@ -34,6 +33,7 @@ resource "redpanda_cluster" "test" {
 variable "resource_group_name" {
   default = "testname"
 }
+
 variable "network_name" {
   default = "testname"
 }

--- a/examples/cluster/gcp/main.tf
+++ b/examples/cluster/gcp/main.tf
@@ -28,12 +28,15 @@ resource "redpanda_cluster" "test" {
     "key" = "value"
   }
 }
+
 variable "cluster_name" {
   default = ""
 }
+
 variable "resource_group_name" {
   default = ""
 }
+
 variable "network_name" {
   default = ""
 }

--- a/examples/datasource/main.tf
+++ b/examples/datasource/main.tf
@@ -3,6 +3,7 @@ provider "redpanda" {}
 variable "cluster_id" {
   default = ""
 }
+
 data "redpanda_cluster" "test" {
   id = var.cluster_id
 }
@@ -41,6 +42,7 @@ variable "topic_config" {
     "compression.type" = "snappy"
   }
 }
+
 variable "user_name" {
   default = "test-username"
 }

--- a/examples/provider.tf
+++ b/examples/provider.tf
@@ -10,7 +10,4 @@ terraform {
 provider "redpanda" {
   client_id      = "your_client_id"
   client_secret  = "your_client_secret"
-  cloud_provider = "aws"
-  region         = "us-west-2"
-  zones          = ["us-west-2a", "us-west-2b"]
 }


### PR DESCRIPTION
Provider, region, and zones is not yet supported
to be configured at the provider level, instead
it should be configured in network/cluster.

This commit also runs terraform fmt in all .tf
files