### PR TITLE
[chore] Update .goreleaser.yaml

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,6 @@
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
+version: 2
 builds:
   - env:
       # goreleaser does not work with CGO, it could also complicate
@@ -52,5 +53,3 @@ release:
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
-changelog:
-  skip: true


### PR DESCRIPTION
Version is now a required field, and v2 deprecated the `changelog.skip` field. Enabling this for now.