### PR TITLE
Add support for Cloud's new rate limit headers 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,9 @@ issues:
         - goconst
       text: "string `UNKNOWN` has"
       path: redpanda/utils/utils.go
+    - path: _test\.go
+      linters:
+        - gocognit
 
 # We opt out of all suggested linters and manually pick what we want.
 # Please do not use enable-all.

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ integration_tests:
 	REDPANDA_CLIENT_SECRET=$${REDPANDA_CLIENT_SECRET} \
 	RUN_CLUSTER_TESTS=true \
 	TF_ACC=true \
+	TF_LOG=DEBUG \
 	VERSION=ign \
 	$(GOCMD) test -v -parallel=5 -timeout=0 ./redpanda/tests
 
@@ -112,7 +113,7 @@ test-create:
 	REDPANDA_CLIENT_ID="$${REDPANDA_CLIENT_ID}" \
 	REDPANDA_CLIENT_SECRET="$${REDPANDA_CLIENT_SECRET}" \
 	REDPANDA_CLOUD_ENVIRONMENT="$${REDPANDA_CLOUD_ENVIRONMENT}" \
-	export TF_LOG=DEBUG \
+	TF_LOG=DEBUG \
 	TF_INSECURE_SKIP_PROVIDER_VERIFICATION=true
 	terraform init && \
 	terraform apply -parallelism 10 -auto-approve

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,6 @@ unit_tests:
 	@DEBUG=true \
 	REDPANDA_CLIENT_ID="dummy_id" \
 	REDPANDA_CLIENT_SECRET="dummy_secret" \
-	TF_ACC=false \
 	RUN_CLUSTER_TESTS=false \
 	$(GOCMD) test -short ./...
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,8 +73,7 @@ resource "redpanda_cluster" "test" {
   throughput_tier   = var.throughput_tier
   zones             = var.zones
   allow_deletion    = true
-  tags = {
-    // not actually used as API does not consume it yet but we keep it in state for when it does
+  tags              = {
     "key" = "value"
   }
 }

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -68,8 +68,7 @@ resource "redpanda_cluster" "test" {
   throughput_tier   = var.throughput_tier
   zones             = var.zones
   allow_deletion    = true
-  tags = {
-    // not actually used as API does not consume it yet but we keep it in state for when it does
+  tags              = {
     "key" = "value"
   }
 }

--- a/examples/bulk-data/README.md
+++ b/examples/bulk-data/README.md
@@ -1,0 +1,4 @@
+# Bulk
+
+Examples in this directory are primarily intended to provide test cases and are not particularly informative for actual
+usage. 

--- a/examples/bulk-data/README.md
+++ b/examples/bulk-data/README.md
@@ -1,4 +1,4 @@
 # Bulk
 
-Examples in this directory are primarily intended to provide test cases and are not particularly informative for actual
+Examples in this directory are primarily intended to provide test cases for datasources and are not particularly informative for actual
 usage. 

--- a/examples/bulk-data/main.tf
+++ b/examples/bulk-data/main.tf
@@ -1,0 +1,85 @@
+provider "redpanda" {
+}
+
+data "redpanda_cluster" "test" {
+  id = var.cluster_id
+}
+
+resource "redpanda_user" "test" {
+  name            = var.user_name
+  password        = var.user_pw
+  mechanism       = var.mechanism
+  cluster_api_url = data.redpanda_cluster.test.cluster_api_url
+}
+
+resource "redpanda_topic" "test" {
+  count              = 100
+  name               = "${var.topic_name}_${count.index + 1}"
+  partition_count    = var.partition_count
+  replication_factor = var.replication_factor
+  cluster_api_url    = data.redpanda_cluster.test.cluster_api_url
+  allow_deletion     = true
+}
+
+resource "redpanda_acl" "test" {
+  count                 = 100
+  resource_type         = "TOPIC"
+  resource_name         = redpanda_topic.test[count.index].name
+  resource_pattern_type = "LITERAL"
+  principal             = "User:${redpanda_user.test.name}"
+  host                  = "*"
+  operation             = "READ"
+  permission_type       = "ALLOW"
+  cluster_api_url       = data.redpanda_cluster.test.cluster_api_url
+}
+
+variable "cluster_id" {
+  default = "testname"
+}
+variable "resource_group_name" {
+  default = "tfrp-acc-testbulk-aKtA"
+}
+
+variable "network_name" {
+  default = "public-network-rate-limit-test"
+}
+
+variable "cluster_name" {
+  default = "rate-limit-test"
+}
+
+variable "region" {
+  default = "us-east-2"
+}
+
+variable "zones" {
+  default = ["use1-az2", "use1-az4", "use1-az6"]
+}
+
+variable "cloud_provider" {
+  default = "aws"
+}
+
+variable "user_name" {
+  default = "test-username"
+}
+
+variable "user_pw" {
+  default = "password"
+}
+
+variable "mechanism" {
+  default = "scram-sha-256"
+}
+
+variable "topic_name" {
+  default = "test-topic"
+}
+
+variable "partition_count" {
+  default = 3
+}
+
+variable "replication_factor" {
+  default = 3
+}

--- a/examples/bulk-res/README.md
+++ b/examples/bulk-res/README.md
@@ -1,0 +1,4 @@
+# Bulk
+
+Examples in this directory are primarily intended to provide test cases and are not particularly informative for actual
+usage. 

--- a/examples/bulk-res/README.md
+++ b/examples/bulk-res/README.md
@@ -1,4 +1,4 @@
 # Bulk
 
-Examples in this directory are primarily intended to provide test cases and are not particularly informative for actual
+Examples in this directory are primarily intended to provide test cases for resources and are not particularly informative for actual
 usage. 

--- a/examples/bulk-res/main.tf
+++ b/examples/bulk-res/main.tf
@@ -1,0 +1,124 @@
+terraform {
+  required_providers {
+    redpanda = {
+      source = "redpanda-data/redpanda"
+    }
+  }
+}
+
+provider "redpanda" {
+  # Configuration options for the redpanda provider
+}
+
+resource "redpanda_resource_group" "test" {
+  name = var.resource_group_name
+}
+
+resource "redpanda_network" "test" {
+  name              = var.network_name
+  resource_group_id = redpanda_resource_group.test.id
+  cloud_provider    = var.cloud_provider
+  region            = var.region
+  cluster_type      = "dedicated"
+  cidr_block        = "10.0.0.0/20"
+}
+
+
+resource "redpanda_cluster" "test" {
+  name              = var.cluster_name
+  resource_group_id = redpanda_resource_group.test.id
+  network_id        = redpanda_network.test.id
+  cloud_provider    = var.cloud_provider
+  region            = var.region
+  cluster_type      = "dedicated"
+  connection_type   = "public"
+  throughput_tier   = var.throughput_tier
+  zones             = var.zones
+  allow_deletion    = true
+  tags = {
+    // not actually used as API does not consume it yet but we keep it in state for when it does
+    "key" = "value"
+  }
+}
+resource "redpanda_user" "test" {
+  name            = var.user_name
+  password        = var.user_pw
+  mechanism       = var.mechanism
+  cluster_api_url = redpanda_cluster.test.cluster_api_url
+}
+
+resource "redpanda_topic" "test" {
+  count              = 100
+  name               = "${var.topic_name}_${count.index + 1}"
+  partition_count    = var.partition_count
+  replication_factor = var.replication_factor
+  cluster_api_url    = redpanda_cluster.test.cluster_api_url
+  allow_deletion     = true
+}
+
+resource "redpanda_acl" "test" {
+  count                 = 100
+  resource_type         = "TOPIC"
+  resource_name         = redpanda_topic.test[count.index].name
+  resource_pattern_type = "LITERAL"
+  principal             = "User:${redpanda_user.test.name}"
+  host                  = "*"
+  operation             = "READ"
+  permission_type       = "ALLOW"
+  cluster_api_url       = redpanda_cluster.test.cluster_api_url
+}
+
+variable "cluster_id" {
+  default = "testname"
+}
+variable "resource_group_name" {
+  default = "tfrp-acc-testbulk-aKtA"
+}
+
+variable "network_name" {
+  default = "public-network-rate-limit-test"
+}
+
+variable "cluster_name" {
+  default = "rate-limit-test"
+}
+
+variable "region" {
+  default = "us-east-2"
+}
+
+variable "zones" {
+  default = ["use2-az1"]
+}
+
+variable "cloud_provider" {
+  default = "aws"
+}
+
+variable "user_name" {
+  default = "test-username"
+}
+
+variable "user_pw" {
+  default = "password"
+}
+
+variable "mechanism" {
+  default = "scram-sha-256"
+}
+
+variable "topic_name" {
+  default = "test-topic"
+}
+
+variable "partition_count" {
+  default = 3
+}
+
+variable "replication_factor" {
+  default = 3
+}
+
+variable "throughput_tier" {
+  default = "tier-1-aws-v2-arm"
+}

--- a/examples/cluster/aws/main.tf
+++ b/examples/cluster/aws/main.tf
@@ -24,8 +24,7 @@ resource "redpanda_cluster" "test" {
   throughput_tier   = var.throughput_tier
   zones             = var.zones
   allow_deletion    = true
-  tags = {
-    // not actually used as API does not consume it yet but we keep it in state for when it does
+  tags              = {
     "key" = "value"
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-testing v1.8.0
 	github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20240531145821-658cd7bccfeb
+	golang.org/x/time v0.5.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240528184218-531527333157
 	google.golang.org/grpc v1.64.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2010,6 +2010,8 @@ golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20220922220347-f3bd1da661af/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.1.0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.3.0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.5.0 h1:o7cqy6amK/52YcAKIPlM3a+Fpj35zvRj2TP+e1xFSfk=
+golang.org/x/time v0.5.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 golang.org/x/tools v0.0.0-20180525024113-a5b4c53f6e8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/redpanda/cloud/cloud.go
+++ b/redpanda/cloud/cloud.go
@@ -129,7 +129,7 @@ func SpawnConn(url string, authToken string) (*grpc.ClientConn, error) {
 			func(ctx context.Context, method string, req any, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 				start := time.Now()
 				err := invoker(ctx, method, req, reply, cc, opts...)
-				tflog.Debug(ctx, "method: %s, duration: %v, error: %v\n", map[string]any{
+				tflog.Debug(ctx, "Redpanda API call", map[string]any{
 					"method":   method,
 					"duration": time.Since(start),
 					"error":    err,

--- a/redpanda/cloud/ratelimiter.go
+++ b/redpanda/cloud/ratelimiter.go
@@ -1,0 +1,94 @@
+package cloud
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"golang.org/x/time/rate"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+const (
+	limitPeriod = 60.0
+	burstPeriod = 10.0
+)
+
+type rateLimiter struct {
+	limiter *rate.Limiter
+}
+
+func newRateLimiter(limit int) *rateLimiter {
+	return &rateLimiter{
+		limiter: rate.NewLimiter(rate.Limit(limit/limitPeriod), limit/burstPeriod),
+	}
+}
+
+func parseRateLimit(header string) (limit, remaining int, reset time.Duration, err error) {
+	for _, part := range strings.Split(header, ",") {
+		kv := strings.SplitN(strings.TrimSpace(part), "=", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		switch kv[0] {
+		case "limit":
+			limit, err = strconv.Atoi(kv[1])
+			if err != nil {
+				return 0, 0, 0, fmt.Errorf("invalid limit value: %v", err)
+			}
+		case "remaining":
+			remaining, err = strconv.Atoi(kv[1])
+			if err != nil {
+				return 0, 0, 0, fmt.Errorf("invalid remaining value: %v", err)
+			}
+		case "reset":
+			seconds, err := strconv.Atoi(kv[1])
+			if err != nil {
+				return 0, 0, 0, fmt.Errorf("invalid reset value: %v", err)
+			}
+			reset = time.Duration(seconds) * time.Second
+		}
+	}
+	return limit, remaining, reset, nil
+}
+
+func (r *rateLimiter) Limiter(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	var header metadata.MD
+	if err := invoker(ctx, method, req, reply, cc, append(opts, grpc.Header(&header))...); err != nil {
+		return err
+	}
+
+	if rateLimitHeader := header.Get("ratelimit"); len(rateLimitHeader) > 0 {
+		tflog.Debug(ctx, "parsing rate limit headers")
+		limit, remaining, reset, err := parseRateLimit(rateLimitHeader[0])
+		if err != nil {
+			return fmt.Errorf("failed to parse rate limit header: %v", err)
+		}
+
+		tflog.Debug(ctx, "setting limit and burst")
+		r.limiter.SetLimit(rate.Limit(limit / limitPeriod))
+		r.limiter.SetBurst(limit / burstPeriod)
+		if remaining == 0 && reset > 0 {
+			tflog.Warn(ctx, "rate limit exceeded", map[string]any{
+				"limit":     limit,
+				"remaining": remaining,
+				"reset":     reset,
+			})
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(reset + 1*time.Second):
+			}
+		}
+		tflog.Debug(ctx, "rate limit updated", map[string]any{
+			"limit":     limit,
+			"remaining": remaining,
+			"reset":     reset,
+		})
+	}
+	return r.limiter.Wait(ctx)
+}

--- a/redpanda/cloud/ratelimiter_test.go
+++ b/redpanda/cloud/ratelimiter_test.go
@@ -1,0 +1,117 @@
+package cloud
+
+import (
+	"context"
+	"errors"
+	"math"
+	"testing"
+	"time"
+
+	"golang.org/x/time/rate"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+func clampLimit(limit, period float64) rate.Limit {
+	return rate.Limit(math.Floor(limit / period))
+}
+
+func TestRateLimiter_Limiter(t *testing.T) {
+	tests := []struct {
+		name                string
+		initialLimit        int
+		headerLimit         string
+		expectedLimit       rate.Limit
+		invokerError        error
+		expectedError       error
+		consecutiveCalls    int
+		expectedMinDuration time.Duration
+	}{
+		{
+			name:                "Normal update",
+			initialLimit:        200,
+			headerLimit:         "limit=200,remaining=75,reset=30",
+			expectedLimit:       clampLimit(200.0, limitPeriod),
+			invokerError:        nil,
+			expectedError:       nil,
+			consecutiveCalls:    10,
+			expectedMinDuration: time.Second * 7,
+		},
+		{
+			name:                "Rate limit exceeded",
+			initialLimit:        100,
+			headerLimit:         "limit=10,remaining=0,reset=30",
+			expectedLimit:       clampLimit(10.0, limitPeriod),
+			invokerError:        nil,
+			expectedError:       nil,
+			consecutiveCalls:    5,
+			expectedMinDuration: time.Second * 29,
+		},
+		{
+			name:                "Invalid header",
+			initialLimit:        100,
+			headerLimit:         "invalid=header",
+			expectedLimit:       clampLimit(100.0, limitPeriod),
+			invokerError:        nil,
+			expectedError:       errors.New("failed to parse rate limit header: incomplete rate limit header: missing required fields"),
+			consecutiveCalls:    1,
+			expectedMinDuration: 0,
+		},
+		{
+			name:                "Invoker error",
+			initialLimit:        100,
+			headerLimit:         "",
+			expectedLimit:       clampLimit(100.0, limitPeriod),
+			invokerError:        errors.New("invoker error"),
+			expectedError:       errors.New("invoker error"),
+			consecutiveCalls:    1,
+			expectedMinDuration: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rl := newRateLimiter(tt.initialLimit)
+
+			mockInvoker := func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+				if tt.headerLimit != "" {
+					header := metadata.MD{
+						"ratelimit": []string{tt.headerLimit},
+					}
+					for _, opt := range opts {
+						if headerOpt, ok := opt.(grpc.HeaderCallOption); ok {
+							*headerOpt.HeaderAddr = header
+							break
+						}
+					}
+				}
+				return tt.invokerError
+			}
+
+			start := time.Now()
+			var lastErr error
+			for i := 0; i < tt.consecutiveCalls; i++ {
+				lastErr = rl.Limiter(context.Background(), "/test.Method", nil, nil, nil, mockInvoker)
+				if lastErr != nil {
+					break
+				}
+			}
+			duration := time.Since(start)
+
+			if (lastErr != nil) != (tt.expectedError != nil) {
+				t.Errorf("Expected error %v, got %v", tt.expectedError, lastErr)
+			}
+			if tt.expectedError != nil && lastErr != nil && lastErr.Error() != tt.expectedError.Error() {
+				t.Errorf("Expected error message %q, got %q", tt.expectedError, lastErr)
+			}
+
+			if rl.limiter.Limit() != tt.expectedLimit {
+				t.Errorf("Expected limit to be %v, got %v", tt.expectedLimit, rl.limiter.Limit())
+			}
+
+			if duration < tt.expectedMinDuration {
+				t.Errorf("Expected minimum duration of %v, but got %v", tt.expectedMinDuration, duration)
+			}
+		})
+	}
+}

--- a/redpanda/tests/acceptance_test.go
+++ b/redpanda/tests/acceptance_test.go
@@ -24,6 +24,8 @@ const (
 	dedicatedUserACLsTopicFile = "../../examples/user-acl-topic/main.tf"
 	dataSourcesTest            = "../../examples/datasource/main.tf"
 	serverlessClusterFile      = "../../examples/serverless-cluster/main.tf"
+	bulkDataCreateFile         = "../../examples/bulk-data/main.tf"
+	bulkResCreateFile          = "../../examples/bulk-res/main.tf"
 	// These are the resource names as named in the TF files.
 	resourceGroupName      = "redpanda_resource_group.test"
 	networkResourceName    = "redpanda_network.test"
@@ -38,6 +40,7 @@ var (
 	accNamePrepend             = "tfrp-acc-"
 	runClusterTests            = os.Getenv("RUN_CLUSTER_TESTS")
 	runServerlessTests         = os.Getenv("RUN_SERVERLESS_TESTS")
+	runBulkTests               = os.Getenv("RUN_BULK_TESTS")
 	clientID                   = os.Getenv(redpanda.ClientIDEnv)
 	clientSecret               = os.Getenv(redpanda.ClientSecretEnv)
 	testAgainstExistingCluster = os.Getenv("TEST_AGAINST_EXISTING_CLUSTER")
@@ -111,6 +114,122 @@ func TestAccResourceGroup(t *testing.T) {
 			ResourceGroupName: rename,
 			Client:            c,
 		}.SweepResourceGroup,
+	})
+	resource.AddTestSweepers(generateRandomName("resourcegroupSweeper"), &resource.Sweeper{
+		Name: name,
+		F: sweepResourceGroup{
+			ResourceGroupName: name,
+			Client:            c,
+		}.SweepResourceGroup,
+	})
+}
+
+func TestAccResourcesBulkData(t *testing.T) {
+	if !strings.Contains(runBulkTests, "true") {
+		t.Skip("skipping cluster tests")
+	}
+	ctx := context.Background()
+
+	name := generateRandomName(accNamePrepend + "testbulk")
+	origTestCaseVars := make(map[string]config.Variable)
+	maps.Copy(origTestCaseVars, providerCfgIDSecretVars)
+	origTestCaseVars["resource_group_name"] = config.StringVariable(name)
+	origTestCaseVars["network_name"] = config.StringVariable(name)
+	origTestCaseVars["cluster_name"] = config.StringVariable(name)
+	origTestCaseVars["cluster_id"] = config.StringVariable(os.Getenv("BULK_CLUSTER_ID"))
+
+	c, err := newTestClients(ctx, clientID, clientSecret, "ign")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				ConfigFile:               config.StaticFile(bulkDataCreateFile),
+				ConfigVariables:          origTestCaseVars,
+				ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+			},
+			{
+				ConfigFile:               config.StaticFile(bulkDataCreateFile),
+				ConfigVariables:          origTestCaseVars,
+				Destroy:                  true,
+				ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+			},
+		},
+	},
+	)
+	resource.AddTestSweepers(generateRandomName("clusterSweeper"), &resource.Sweeper{
+		Name: name,
+		F: sweepCluster{
+			ClusterName: name,
+			Client:      c,
+		}.SweepCluster,
+	})
+	resource.AddTestSweepers(generateRandomName("networkSweeper"), &resource.Sweeper{
+		Name: name,
+		F: sweepNetwork{
+			NetworkName: name,
+			Client:      c,
+		}.SweepNetworks,
+	})
+	resource.AddTestSweepers(generateRandomName("resourcegroupSweeper"), &resource.Sweeper{
+		Name: name,
+		F: sweepResourceGroup{
+			ResourceGroupName: name,
+			Client:            c,
+		}.SweepResourceGroup,
+	})
+}
+
+func TestAccResourcesBulkRes(t *testing.T) {
+	if !strings.Contains(runBulkTests, "true") {
+		t.Skip("skipping cluster tests")
+	}
+	ctx := context.Background()
+
+	name := generateRandomName(accNamePrepend + "testbulk")
+	origTestCaseVars := make(map[string]config.Variable)
+	maps.Copy(origTestCaseVars, providerCfgIDSecretVars)
+	origTestCaseVars["resource_group_name"] = config.StringVariable(name)
+	origTestCaseVars["network_name"] = config.StringVariable(name)
+	origTestCaseVars["cluster_name"] = config.StringVariable(name)
+	origTestCaseVars["cluster_id"] = config.StringVariable(os.Getenv("BULK_CLUSTER_ID"))
+
+	c, err := newTestClients(ctx, clientID, clientSecret, "ign")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				ConfigFile:               config.StaticFile(bulkResCreateFile),
+				ConfigVariables:          origTestCaseVars,
+				ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+			},
+			{
+				ConfigFile:               config.StaticFile(bulkResCreateFile),
+				ConfigVariables:          origTestCaseVars,
+				Destroy:                  true,
+				ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+			},
+		},
+	},
+	)
+	resource.AddTestSweepers(generateRandomName("clusterSweeper"), &resource.Sweeper{
+		Name: name,
+		F: sweepCluster{
+			ClusterName: name,
+			Client:      c,
+		}.SweepCluster,
+	})
+	resource.AddTestSweepers(generateRandomName("networkSweeper"), &resource.Sweeper{
+		Name: name,
+		F: sweepNetwork{
+			NetworkName: name,
+			Client:      c,
+		}.SweepNetworks,
 	})
 	resource.AddTestSweepers(generateRandomName("resourcegroupSweeper"), &resource.Sweeper{
 		Name: name,


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-ratelimit-headers#name-ratelimit-header-field-defi

Relevant RFC used on the API side. I also added a bulk test case and info on what it's doing there. 

Fixes #108 