### PR TITLE
cloud: remove extra polling on long running create operations

### DIFF
--- a/redpanda/resources/cluster/resource_cluster.go
+++ b/redpanda/resources/cluster/resource_cluster.go
@@ -171,10 +171,6 @@ func (c *Cluster) Create(ctx context.Context, req resource.CreateRequest, resp *
 		resp.Diagnostics.AddError("failed to create cluster", err.Error())
 		return
 	}
-	if _, err := utils.GetClusterUntilRunningState(ctx, 0, 80, clusterReq.Name, c.CpCl); err != nil {
-		resp.Diagnostics.AddError("failed at getting ready state while creating cluster", err.Error())
-		return
-	}
 	op := clResp.Operation
 	var metadata controlplanev1beta2.CreateClusterMetadata
 	if err := op.Metadata.UnmarshalTo(&metadata); err != nil {

--- a/redpanda/resources/serverlesscluster/resource_serverless_cluster.go
+++ b/redpanda/resources/serverlesscluster/resource_serverless_cluster.go
@@ -123,10 +123,6 @@ func (c *ServerlessCluster) Create(ctx context.Context, req resource.CreateReque
 		resp.Diagnostics.AddError("failed to create serverless cluster", err.Error())
 		return
 	}
-	if _, err := utils.GetServerlessClusterUntilRunningState(ctx, 0, 80, clusterReq.Name, c.CpCl); err != nil {
-		resp.Diagnostics.AddError("failed at getting ready state while creating serverless cluster", err.Error())
-		return
-	}
 	operation, err := c.CpCl.Operation.GetOperation(ctx, &controlplanev1beta2.GetOperationRequest{Id: clResp.Operation.Id})
 	if err != nil {
 		resp.Diagnostics.AddError("failed to retrieve create serverless cluster operation", err.Error())


### PR DESCRIPTION
[This](https://github.com/redpanda-data/cloudv2/pull/16130/commits/c1fc6e1a852b653af832a416615443dba7e85f7b#diff-4b4a8e677856278bcb41f45226b72c24a27cbe8e5033093ebd4ce6a4e7f4ab13) cloud PR ensures that resourceId and metadata are returned in the initial operation response on create operations (createCluster and createServerlessCluster). Given this improvement, it is no longer necessary to poll until the operation is complete to get the metadata in the terraform provider.