### PR TITLE
gha: fix node16 warn

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           # Allow goreleaser to access older tag information.
           fetch-depth: 0
-      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
           go-version-file: 'go.mod'
           cache: true


### PR DESCRIPTION
fixes warning when goreleaser job is run:
> The following actions uses Node.js version which is deprecated and will be forced to run on node20: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe.
> For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

e.g. https://github.com/redpanda-data/terraform-provider-redpanda/actions/runs/10202429395

the v5.0.0 [release](https://github.com/actions/setup-go/releases) of setup-go uses node20 and v5.0.2 is the latest