### PR TITLE
fix: Make rule tf-init should delete lockfile to avoid checksum errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,7 @@ tf-init:
 	@echo "Initializing Terraform..."
 	@cd $(call GET_TF_CONFIG_DIR) && \
 	ls -ltrah && \
+	rm -f .terraform.lock.hcl && \
 	REDPANDA_CLIENT_ID="$(REDPANDA_CLIENT_ID)" \
 	REDPANDA_CLIENT_SECRET="$(REDPANDA_CLIENT_SECRET)" \
 	REDPANDA_CLOUD_ENVIRONMENT="$(REDPANDA_CLOUD_ENVIRONMENT)" \


### PR DESCRIPTION
Happens after rebuilding the plugin with a different checksum