### PR TITLE
chore: don't validate throughput tier when creating cluster

### DIFF
--- a/redpanda/resources/cluster/resource_cluster.go
+++ b/redpanda/resources/cluster/resource_cluster.go
@@ -338,10 +338,6 @@ func (c *Cluster) Create(ctx context.Context, req resource.CreateRequest, resp *
 		return
 	}
 
-	if err := utils.ValidateThroughputTier(ctx, c.CpCl.ThroughputTier, clusterReq.GetThroughputTier(), model.CloudProvider.ValueString(), "dedicated", clusterReq.GetRegion()); err != nil {
-		return
-	}
-
 	clResp, err := c.CpCl.Cluster.CreateCluster(ctx, &controlplanev1beta2.CreateClusterRequest{Cluster: clusterReq})
 	if err != nil {
 		resp.Diagnostics.AddError("failed to create cluster", err.Error())

--- a/redpanda/utils/utils_test.go
+++ b/redpanda/utils/utils_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/redpanda-data/terraform-provider-redpanda/redpanda/mocks"
-	"github.com/stretchr/testify/assert"
 	"google.golang.org/genproto/googleapis/rpc/status"
 )
 
@@ -626,99 +625,6 @@ func TestFindTopicByName(t *testing.T) {
 
 			if !reflect.DeepEqual(topic, tc.expectedTopic) {
 				t.Errorf("Expected topic %+v, but got %+v", tc.expectedTopic, topic)
-			}
-		})
-	}
-}
-
-func TestValidateThroughputTier(t *testing.T) {
-	tests := []struct {
-		name           string
-		throughputTier string
-		cloudProvider  string
-		clusterType    string
-		region         string
-		mockSetup      func(*mocks.MockThroughputTierClient)
-		expectedError  string
-	}{
-		{
-			name:           "Valid throughput tier",
-			throughputTier: "tier-1",
-			cloudProvider:  "aws",
-			clusterType:    "dedicated",
-			region:         "us-east-1",
-			mockSetup: func(m *mocks.MockThroughputTierClient) {
-				m.EXPECT().ListThroughputTiers(gomock.Any(), gomock.Any()).Return(&controlplanev1beta2.ListThroughputTiersResponse{
-					ThroughputTiers: []*controlplanev1beta2.ThroughputTier{
-						{Name: "tier-1"},
-						{Name: "tier-2"},
-					},
-				}, nil)
-			},
-			expectedError: "",
-		},
-		{
-			name:           "Invalid throughput tier",
-			throughputTier: "tier-3",
-			cloudProvider:  "aws",
-			clusterType:    "dedicated",
-			region:         "us-east-1",
-			mockSetup: func(m *mocks.MockThroughputTierClient) {
-				m.EXPECT().ListThroughputTiers(gomock.Any(), gomock.Any()).Return(&controlplanev1beta2.ListThroughputTiersResponse{
-					ThroughputTiers: []*controlplanev1beta2.ThroughputTier{
-						{Name: "tier-1"},
-						{Name: "tier-2"},
-					},
-				}, nil)
-			},
-			expectedError: "invalid throughput tier tier-3, please select a valid throughput tier",
-		},
-		{
-			name:           "API error",
-			throughputTier: "tier-1",
-			cloudProvider:  "aws",
-			clusterType:    "dedicated",
-			region:         "us-east-1",
-			mockSetup: func(m *mocks.MockThroughputTierClient) {
-				m.EXPECT().ListThroughputTiers(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("API error"))
-			},
-			expectedError: "API error",
-		},
-		{
-			name:           "Invalid cloud provider",
-			throughputTier: "tier-1",
-			cloudProvider:  "invalid",
-			clusterType:    "dedicated",
-			region:         "us-east-1",
-			mockSetup:      func(_ *mocks.MockThroughputTierClient) {},
-			expectedError:  "provider \"invalid\" not supported",
-		},
-		{
-			name:           "Invalid cluster type",
-			throughputTier: "tier-1",
-			cloudProvider:  "aws",
-			clusterType:    "invalid",
-			region:         "us-east-1",
-			mockSetup:      func(_ *mocks.MockThroughputTierClient) {},
-			expectedError:  "cluster type \"invalid\" not supported",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-
-			mockClient := mocks.NewMockThroughputTierClient(ctrl)
-			tt.mockSetup(mockClient)
-
-			err := ValidateThroughputTier(context.Background(), mockClient, tt.throughputTier, tt.cloudProvider, tt.clusterType, tt.region)
-
-			if tt.expectedError != "" {
-				assert.Error(t, err)
-				assert.Contains(t, err.Error(), tt.expectedError)
-			} else {
-				assert.NoError(t, err)
 			}
 		})
 	}


### PR DESCRIPTION
The CreateCluster call itself will validate the throughput tiers already, so this is just extra work. This also will work if CreateCluster ever changes its own internal validation logic.