### PR TITLE
Fixes to network resource and data source state

### DIFF
--- a/redpanda/resources/network/data_network.go
+++ b/redpanda/resources/network/data_network.go
@@ -24,11 +24,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/redpanda-data/terraform-provider-redpanda/redpanda/cloud"
 	"github.com/redpanda-data/terraform-provider-redpanda/redpanda/config"
 	"github.com/redpanda-data/terraform-provider-redpanda/redpanda/models"
-	"github.com/redpanda-data/terraform-provider-redpanda/redpanda/utils"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -109,15 +107,7 @@ func (n *DataSourceNetwork) Read(ctx context.Context, req datasource.ReadRequest
 		resp.Diagnostics.AddError(fmt.Sprintf("failed to read network %s", model.ID.ValueString()), err.Error())
 		return
 	}
-	resp.Diagnostics.Append(resp.State.Set(ctx, models.Network{
-		Name:            types.StringValue(nw.Name),
-		ID:              types.StringValue(nw.Id),
-		CidrBlock:       types.StringValue(nw.CidrBlock),
-		Region:          types.StringValue(nw.Region),
-		ResourceGroupID: types.StringValue(nw.ResourceGroupId),
-		CloudProvider:   types.StringValue(utils.CloudProviderToString(nw.CloudProvider)),
-		ClusterType:     types.StringValue(utils.ClusterTypeToString(nw.ClusterType)),
-	})...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, generateModel(nw))...)
 }
 
 // Configure uses provider level data to configure DataSourceNetwork's client.

--- a/redpanda/resources/network/data_network.go
+++ b/redpanda/resources/network/data_network.go
@@ -28,6 +28,7 @@ import (
 	"github.com/redpanda-data/terraform-provider-redpanda/redpanda/cloud"
 	"github.com/redpanda-data/terraform-provider-redpanda/redpanda/config"
 	"github.com/redpanda-data/terraform-provider-redpanda/redpanda/models"
+	"github.com/redpanda-data/terraform-provider-redpanda/redpanda/utils"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -105,13 +106,17 @@ func (n *DataSourceNetwork) Read(ctx context.Context, req datasource.ReadRequest
 	resp.Diagnostics.Append(req.Config.Get(ctx, &model)...)
 	nw, err := n.CpCl.NetworkForID(ctx, model.ID.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("failed to read network", err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("failed to read network %s", model.ID.ValueString()), err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, models.Network{
-		Name: types.StringValue(nw.Name),
-		ID:   types.StringValue(nw.Id),
-		// Map other network attributes here as needed
+		Name:            types.StringValue(nw.Name),
+		ID:              types.StringValue(nw.Id),
+		CidrBlock:       types.StringValue(nw.CidrBlock),
+		Region:          types.StringValue(nw.Region),
+		ResourceGroupID: types.StringValue(nw.ResourceGroupId),
+		CloudProvider:   types.StringValue(utils.CloudProviderToString(nw.CloudProvider)),
+		ClusterType:     types.StringValue(utils.ClusterTypeToString(nw.ClusterType)),
 	})...)
 }
 

--- a/redpanda/resources/network/network.go
+++ b/redpanda/resources/network/network.go
@@ -1,0 +1,35 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package network
+
+import (
+	controlplanev1beta2 "buf.build/gen/go/redpandadata/cloud/protocolbuffers/go/redpanda/api/controlplane/v1beta2"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/redpanda-data/terraform-provider-redpanda/redpanda/models"
+	"github.com/redpanda-data/terraform-provider-redpanda/redpanda/utils"
+)
+
+func generateModel(nw *controlplanev1beta2.Network) *models.Network {
+	return &models.Network{
+		CidrBlock:       types.StringValue(nw.CidrBlock),
+		CloudProvider:   types.StringValue(utils.CloudProviderToString(nw.CloudProvider)),
+		ClusterType:     types.StringValue(utils.ClusterTypeToString(nw.ClusterType)),
+		ID:              types.StringValue(nw.Id),
+		Name:            types.StringValue(nw.Name),
+		Region:          types.StringValue(nw.Region),
+		ResourceGroupID: types.StringValue(nw.ResourceGroupId),
+	}
+}

--- a/redpanda/resources/network/resource_network.go
+++ b/redpanda/resources/network/resource_network.go
@@ -171,14 +171,20 @@ func (n *Network) Create(ctx context.Context, request resource.CreateRequest, re
 		response.Diagnostics.AddError("failed waiting for network creation", err.Error())
 		return
 	}
+
+	nw, err := n.CpCl.NetworkForID(ctx, op.GetResourceId())
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("failed to read network %s", op.GetResourceId()), err.Error())
+		return
+	}
 	response.Diagnostics.Append(response.State.Set(ctx, models.Network{
-		Name:            model.Name,
-		ID:              utils.TrimmedStringValue(op.GetResourceId()),
-		CidrBlock:       model.CidrBlock,
-		Region:          model.Region,
-		ResourceGroupID: model.ResourceGroupID,
-		ClusterType:     model.ClusterType,
-		CloudProvider:   model.CloudProvider,
+		Name:            types.StringValue(nw.Name),
+		ID:              types.StringValue(nw.Id),
+		CidrBlock:       types.StringValue(nw.CidrBlock),
+		Region:          types.StringValue(nw.Region),
+		ResourceGroupID: types.StringValue(nw.ResourceGroupId),
+		CloudProvider:   types.StringValue(utils.CloudProviderToString(nw.CloudProvider)),
+		ClusterType:     types.StringValue(utils.ClusterTypeToString(nw.ClusterType)),
 	})...)
 }
 

--- a/redpanda/resources/network/resource_network.go
+++ b/redpanda/resources/network/resource_network.go
@@ -31,7 +31,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/redpanda-data/terraform-provider-redpanda/redpanda/cloud"
 	"github.com/redpanda-data/terraform-provider-redpanda/redpanda/config"
 	"github.com/redpanda-data/terraform-provider-redpanda/redpanda/models"
@@ -177,15 +176,7 @@ func (n *Network) Create(ctx context.Context, request resource.CreateRequest, re
 		response.Diagnostics.AddError(fmt.Sprintf("failed to read network %s", op.GetResourceId()), err.Error())
 		return
 	}
-	response.Diagnostics.Append(response.State.Set(ctx, models.Network{
-		Name:            types.StringValue(nw.Name),
-		ID:              types.StringValue(nw.Id),
-		CidrBlock:       types.StringValue(nw.CidrBlock),
-		Region:          types.StringValue(nw.Region),
-		ResourceGroupID: types.StringValue(nw.ResourceGroupId),
-		CloudProvider:   types.StringValue(utils.CloudProviderToString(nw.CloudProvider)),
-		ClusterType:     types.StringValue(utils.ClusterTypeToString(nw.ClusterType)),
-	})...)
+	response.Diagnostics.Append(response.State.Set(ctx, generateModel(nw))...)
 }
 
 // Read reads Network resource's values and updates the state.
@@ -208,15 +199,7 @@ func (n *Network) Read(ctx context.Context, request resource.ReadRequest, respon
 		response.Diagnostics.AddWarning(fmt.Sprintf("network %s is in state %s", nw.Id, nw.GetState()), "")
 		return
 	}
-	response.Diagnostics.Append(response.State.Set(ctx, models.Network{
-		Name:            types.StringValue(nw.Name),
-		ID:              types.StringValue(nw.Id),
-		CidrBlock:       types.StringValue(nw.CidrBlock),
-		Region:          types.StringValue(nw.Region),
-		ResourceGroupID: types.StringValue(nw.ResourceGroupId),
-		CloudProvider:   types.StringValue(utils.CloudProviderToString(nw.CloudProvider)),
-		ClusterType:     types.StringValue(utils.ClusterTypeToString(nw.ClusterType)),
-	})...)
+	response.Diagnostics.Append(response.State.Set(ctx, generateModel(nw))...)
 }
 
 // Update is not supported for network. As a result all configurable schema


### PR DESCRIPTION
* **fix: set network resource state from api response, not plan**: This will catch any cases where the API response doesn't match instead
of silently ignoring it.

* **feat: network data source reads all attributes**: add `cidr_block`, `cloud_provider`, `cluster_type`, `region`, and `resource_group_id` to the network data source

* **chore: extract network.generateModel()**: extracts the "Network API Response to Terraform model" logic which is duplicated in three places into its own file, following the same pattern as the Cluster resource