### PR TITLE
fix: pass mTLS certificates correctly (TypeListToStringSlice shouldn't quote special characters)

### DIFF
--- a/redpanda/utils/utils.go
+++ b/redpanda/utils/utils.go
@@ -174,9 +174,18 @@ func ConnectionTypeToString(t controlplanev1beta2.Cluster_ConnectionType) string
 // TypeListToStringSlice converts a types.List to a []string, stripping
 // surrounding quotes for each element.
 func TypeListToStringSlice(t types.List) []string {
-	var s []string
+	if t.IsNull() {
+		return nil
+	}
+	s := []string{}
 	for _, v := range t.Elements() {
-		s = append(s, strings.Trim(v.String(), "\"")) // it's easier to strip the quotes than type converting until you hit something that doesn't include them
+		stringval, ok := v.(types.String)
+		if ok {
+			s = append(s, stringval.ValueString())
+		} else {
+			// TODO: issue #173 - ensure this is only called on types.List that actually hold strings
+			s = append(s, strings.Trim(v.String(), "\"")) // it's easier to strip the quotes than type converting until you hit something that doesn't include them
+		}
 	}
 	return s
 }

--- a/redpanda/utils/utils_test.go
+++ b/redpanda/utils/utils_test.go
@@ -182,9 +182,19 @@ func TestTypeListToStringSlice(t *testing.T) {
 			expected: []string{"a", "b", "c"},
 		},
 		{
+			name:     "test special character conversion",
+			input:    StringSliceToTypeList([]string{"---BEGIN CERTIFICATE---\nhello world\n---END CERTIFICATE---\n"}),
+			expected: []string{"---BEGIN CERTIFICATE---\nhello world\n---END CERTIFICATE---\n"},
+		},
+		{
+			name:     "test nil conversion",
+			input:    StringSliceToTypeList(nil),
+			expected: nil,
+		},
+		{
 			name:     "test empty conversion",
 			input:    StringSliceToTypeList([]string{}),
-			expected: nil,
+			expected: []string{},
 		},
 	}
 


### PR DESCRIPTION
When calling it on actual strings, the string gets quoted and special characters like newlines are escaped. It was trimming the quotes but not fixing escaped characters. This was messing up passing mTLS PEM-format certificates, which contain newlines.

Change the logic if called on a types.List that has actual types.String values so we keep the exact string value. Ideally this function is somehow typed so it can only ever be called on types.List that have strings but that seems like a bigger project.