### PR TITLE
ci: fix automated release

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -41,6 +41,11 @@ signs:
       # if you are using this in a GitHub action or some other automated pipeline, you
       # need to pass the batch flag to indicate its not interactive.
       - "--batch"
+      - "--no-tty"
+      - "--pinentry-mode"
+      - "loopback"
+      - "--passphrase"
+      - "{{ .Env.PASSPHRASE }}"
       - "--local-user"
       - "{{ .Env.GPG_FINGERPRINT }}" # set this environment variable for your signing key
       - "--output"

--- a/Makefile
+++ b/Makefile
@@ -378,8 +378,8 @@ test_serverless_cluster:
 	$(GOCMD) test -v -timeout=$(TIMEOUT) ./redpanda/tests -run TestAccResourcesStrippedDownServerlessCluster
 
 import-gpg:
-	echo "$$GPG_PRIVATE_KEY" | gpg --batch --pinentry-mode loopback --passphrase "$$PASSPHRASE" --import
+	echo "$$GPG_PRIVATE_KEY" | base64 -d | gpg --batch --pinentry-mode loopback --passphrase "$$PASSPHRASE" --import
 
 .PHONY: release
 release: import-gpg
-	goreleaser release --clean
+	goreleaser release --clean --verbose


### PR DESCRIPTION
Makes goreleaser verbose so we can see the errors and properly converts the gpg key from base64.

Also fixes gpg was attempting to ask for the passphrase with an interactive request. This method of invoking it via goreleaser's config file prevents that.

From the manpage:

If this command is used with --batch, --pinentry-mode has been set to loopback, and one of the passphrase options (--passphrase, --passphrase-fd, or
              --passphrase-file) is used, the supplied passphrase is used for the new key and the agent does not ask for it.