### PR TITLE
feat: add config vars

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,10 +16,15 @@ The Redpanda provider is designed for managing Redpanda clusters and Kafka resou
 ### Optional
 
 - `access_token` (String, Sensitive) Redpanda client token. You need either `access_token`, or both `client_id` and `client_secret` to use this provider. Can also be set with the `REDPANDA_ACCESS_TOKEN` environment variable.
+- `azure_client_id` (String) Used for creating and managing BYOC and BYOVPC clusters. Can also be specified in the environment as AZURE_CLIENT_ID or ARM_CLIENT_ID
+- `azure_client_secret` (String) Used for creating and managing BYOC and BYOVPC clusters. Can also be specified in the environment as AZURE_CLIENT_SECRET or ARM_CLIENT_SECRET
 - `azure_subscription_id` (String) The default Azure Subscription ID which should be used for Redpanda BYOC clusters. If another subscription is specified on a resource, it will take precedence. This can also be sourced from the `ARM_SUBSCRIPTION_ID` environment variable.
+- `azure_tenant_id` (String) Used for creating and managing BYOC and BYOVPC clusters. Can also be specified in the environment as AZURE_TENANT_ID or ARM_TENANT_ID
 - `client_id` (String, Sensitive) The ID for the client. You need either `client_id` AND `client_secret`, or `access_token`, to use this provider. Can also be set with the `REDPANDA_CLIENT_ID` environment variable.
 - `client_secret` (String, Sensitive) Redpanda client secret. You need either `client_id` AND `client_secret`, or `access_token`, to use this provider. Can also be set with the `REDPANDA_CLIENT_SECRET` environment variable.
 - `gcp_project_id` (String) The default Google Cloud Project ID to use for Redpanda BYOC clusters. If another project is specified on a resource, it will take precedence. This can also be sourced from the `GOOGLE_PROJECT` environment variable, or any of the following ordered by precedence: `GOOGLE_PROJECT`, `GOOGLE_CLOUD_PROJECT`, `GCLOUD_PROJECT`, or `CLOUDSDK_CORE_PROJECT`.
+- `google_credentials` (String) Used for creating and managing BYOC and BYOVPC clusters. Can also be specified in the environment as GOOGLE_CREDENTIALS
+- `google_credentials_base64` (String) Used for creating and managing BYOC and BYOVPC clusters. Is a convenience passthrough for base64 encoded credentials intended for use in CI/CD. Can also be specified in the environment as GOOGLE_CREDENTIALS_BASE64
 
 ## Authentication with Redpanda Cloud
 

--- a/redpanda/models/redpanda.go
+++ b/redpanda/models/redpanda.go
@@ -21,9 +21,14 @@ import (
 
 // Redpanda represents the Terraform schema for the Redpanda TF provider.
 type Redpanda struct {
-	AccessToken         types.String `tfsdk:"access_token"`
-	ClientID            types.String `tfsdk:"client_id"`
-	ClientSecret        types.String `tfsdk:"client_secret"`
-	AzureSubscriptionID types.String `tfsdk:"azure_subscription_id"`
-	GcpProjectID        types.String `tfsdk:"gcp_project_id"`
+	AccessToken             types.String `tfsdk:"access_token"`
+	ClientID                types.String `tfsdk:"client_id"`
+	ClientSecret            types.String `tfsdk:"client_secret"`
+	AzureSubscriptionID     types.String `tfsdk:"azure_subscription_id"`
+	GcpProjectID            types.String `tfsdk:"gcp_project_id"`
+	AzureClientID           types.String `tfsdk:"azure_client_id"`
+	AzureClientSecret       types.String `tfsdk:"azure_client_secret"`
+	AzureTenantID           types.String `tfsdk:"azure_tenant_id"`
+	GoogleCredentials       types.String `tfsdk:"google_credentials"`
+	GoogleCredentialsBase64 types.String `tfsdk:"google_credentials_base64"`
 }

--- a/redpanda/redpanda.go
+++ b/redpanda/redpanda.go
@@ -134,6 +134,26 @@ func providerSchema() schema.Schema {
 					" the `GOOGLE_PROJECT` environment variable, or any of the following ordered by precedence:" +
 					" `GOOGLE_PROJECT`, `GOOGLE_CLOUD_PROJECT`, `GCLOUD_PROJECT`, or `CLOUDSDK_CORE_PROJECT`."),
 			},
+			"azure_client_id": schema.StringAttribute{
+				Optional:    true,
+				Description: ("Used for creating and managing BYOC and BYOVPC clusters. Can also be specified in the environment as AZURE_CLIENT_ID or ARM_CLIENT_ID"),
+			},
+			"azure_client_secret": schema.StringAttribute{
+				Optional:    true,
+				Description: ("Used for creating and managing BYOC and BYOVPC clusters. Can also be specified in the environment as AZURE_CLIENT_SECRET or ARM_CLIENT_SECRET"),
+			},
+			"azure_tenant_id": schema.StringAttribute{
+				Optional:    true,
+				Description: ("Used for creating and managing BYOC and BYOVPC clusters. Can also be specified in the environment as AZURE_TENANT_ID or ARM_TENANT_ID"),
+			},
+			"google_credentials": schema.StringAttribute{
+				Optional:    true,
+				Description: ("Used for creating and managing BYOC and BYOVPC clusters. Can also be specified in the environment as GOOGLE_CREDENTIALS"),
+			},
+			"google_credentials_base64": schema.StringAttribute{
+				Optional:    true,
+				Description: ("Used for creating and managing BYOC and BYOVPC clusters. Is a convenience passthrough for base64 encoded credentials intended for use in CI/CD. Can also be specified in the environment as GOOGLE_CREDENTIALS_BASE64"),
+			},
 		},
 		Description:         "Redpanda Data terraform provider",
 		MarkdownDescription: "Provider configuration",
@@ -281,16 +301,25 @@ func (r *Redpanda) Configure(ctx context.Context, request provider.ConfigureRequ
 		os.Getenv("GCLOUD_PROJECT"),
 		os.Getenv("CLOUDSDK_CORE_PROJECT"))
 	azureClientID := firstNonEmptyString(
+		conf.AzureClientID.ValueString(),
 		os.Getenv("AZURE_CLIENT_ID"),
 		os.Getenv("ARM_CLIENT_ID"))
 	azureClientSecret := firstNonEmptyString(
+		conf.AzureClientSecret.ValueString(),
 		os.Getenv("AZURE_CLIENT_SECRET"),
 		os.Getenv("ARM_CLIENT_SECRET"))
 	azureTenantID := firstNonEmptyString(
+		conf.AzureTenantID.ValueString(),
 		os.Getenv("AZURE_TENANT_ID"),
 		os.Getenv("ARM_TENANT_ID"))
-	googleCredentials := os.Getenv("GOOGLE_CREDENTIALS")
-	googleCredentialsBase64 := os.Getenv("GOOGLE_CREDENTIALS_BASE64")
+	googleCredentials := firstNonEmptyString(
+		conf.GoogleCredentials.ValueString(),
+		os.Getenv("GOOGLE_CREDENTIALS"),
+	)
+	googleCredentialsBase64 := firstNonEmptyString(
+		conf.GoogleCredentialsBase64.ValueString(),
+		os.Getenv("GOOGLE_CREDENTIALS_BASE64"),
+	)
 	if r.byoc == nil {
 		r.byoc = utils.NewByocClient(utils.ByocClientConfig{
 			AuthToken:               creds.Token,


### PR DESCRIPTION
Adds the various config vars needed for byoc/byovpc that weren't already available as config vars (but were available as environment vars) to the config struct for redpanda.