### PR TITLE
feat: support all Azure auth methods for BYOC

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -1106,7 +1106,9 @@ variable "replication_factor" {
 
 ### Azure BYOC
 
-To create a BYOC Azure cluster you must provide an AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TENANT_ID, and AZURE_SUBSCRIPTION_ID. Getting a Tenant ID [requires creating a subscription](https://learn.microsoft.com/en-us/azure/azure-portal/get-subscription-tenant-id). The account [must have fairly wide ranging permissions](https://docs.redpanda.com/redpanda-cloud/security/authorization/cloud-iam-policies-azure/) to create the necessary infrastructure.
+To create a BYOC Azure cluster you must provide Azure credentials, be logged in to the Azure CLI, or specify an Azure authentication method. This provider supports [the same authentication methods and environment variables as the official AzureRM provider](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/azure_cli). For example, to use a service principal and client certificate, you can pass the environment variables `ARM_CLIENT_ID`, `ARM_CLIENT_SECRET`, `ARM_TENANT_ID`, and `ARM_SUBSCRIPTION_ID`.
+
+The account [must have fairly wide ranging permissions](https://docs.redpanda.com/redpanda-cloud/security/authorization/cloud-iam-policies-azure/) to create the necessary infrastructure.
 
 ```terraform
 provider "redpanda" {}

--- a/redpanda/utils/byoc.go
+++ b/redpanda/utils/byoc.go
@@ -20,7 +20,6 @@ package utils
 import (
 	"bufio"
 	"context"
-	"encoding/base64"
 	"fmt"
 	"io"
 	"os"
@@ -38,45 +37,42 @@ import (
 
 // ByocClientConfig represents the options that must be passed to NewByocClient.
 type ByocClientConfig struct {
-	AuthToken               string
-	AzureSubscriptionID     string
-	GcpProject              string
-	InternalAPIURL          string
-	AzureClientID           string
-	AzureClientSecret       string
-	AzureTenantID           string
-	GoogleCredentials       string
-	GoogleCredentialsBase64 string
+	AuthToken           string
+	AzureSubscriptionID string
+	GcpProject          string
+	InternalAPIURL      string
+	AzureClientID       string
+	AzureClientSecret   string
+	AzureTenantID       string
+	GoogleCredentials   string
 }
 
 // ByocClient holds the information and clients needed to download and interact
 // with the rpk byoc plugin.
 type ByocClient struct {
-	api                     *cloudapi.Client
-	authToken               string
-	internalAPIURL          string
-	gcpProject              string
-	azureSubscriptionID     string
-	azureClientID           string
-	azureClientSecret       string
-	azureTenantID           string
-	googleCredentials       string
-	googleCredentialsBase64 string
+	api                 *cloudapi.Client
+	authToken           string
+	internalAPIURL      string
+	gcpProject          string
+	azureSubscriptionID string
+	azureClientID       string
+	azureClientSecret   string
+	azureTenantID       string
+	googleCredentials   string
 }
 
 // NewByocClient creates a new ByocClient.
 func NewByocClient(conf ByocClientConfig) *ByocClient {
 	return &ByocClient{
-		api:                     cloudapi.NewClient(conf.InternalAPIURL, conf.AuthToken),
-		authToken:               conf.AuthToken,
-		internalAPIURL:          conf.InternalAPIURL,
-		gcpProject:              conf.GcpProject,
-		azureSubscriptionID:     conf.AzureSubscriptionID,
-		azureClientID:           conf.AzureClientID,
-		azureClientSecret:       conf.AzureClientSecret,
-		azureTenantID:           conf.AzureTenantID,
-		googleCredentials:       conf.GoogleCredentials,
-		googleCredentialsBase64: conf.GoogleCredentialsBase64,
+		api:                 cloudapi.NewClient(conf.InternalAPIURL, conf.AuthToken),
+		authToken:           conf.AuthToken,
+		internalAPIURL:      conf.InternalAPIURL,
+		gcpProject:          conf.GcpProject,
+		azureSubscriptionID: conf.AzureSubscriptionID,
+		azureClientID:       conf.AzureClientID,
+		azureClientSecret:   conf.AzureClientSecret,
+		azureTenantID:       conf.AzureTenantID,
+		googleCredentials:   conf.GoogleCredentials,
 	}
 }
 
@@ -98,7 +94,7 @@ func (cl *ByocClient) RunByoc(ctx context.Context, clusterID, verb string) error
 		return err
 	}
 
-	return runSubprocess(ctx, cl.internalAPIURL, cl.googleCredentials, cl.googleCredentialsBase64, byocPath, byocArgs...)
+	return runSubprocess(ctx, cl.internalAPIURL, cl.googleCredentials, byocPath, byocArgs...)
 }
 
 func (cl *ByocClient) generateByocArgs(cluster cloudapi.Cluster, verb string) ([]string, error) {
@@ -175,7 +171,7 @@ func (cl *ByocClient) getByocExecutable(ctx context.Context, cluster cloudapi.Cl
 	return byocPath, nil
 }
 
-func runSubprocess(ctx context.Context, cloudURL, gcreds, gcreds64, executable string, args ...string) error {
+func runSubprocess(ctx context.Context, cloudURL, gcreds, executable string, args ...string) error {
 	tempDir, err := os.MkdirTemp("", "terraform-provider-redpanda-byoc")
 	if err != nil {
 		return err
@@ -201,16 +197,6 @@ func runSubprocess(ctx context.Context, cloudURL, gcreds, gcreds64, executable s
 	// Handle credentials file creation
 	if gcreds != "" {
 		if err := os.WriteFile(path.Join(tempDir, "creds.json"), []byte(gcreds), 0o600); err != nil {
-			return err
-		}
-		cmd.Env = append(cmd.Env, fmt.Sprintf("GOOGLE_APPLICATION_CREDENTIALS=%s", path.Join(tempDir, "creds.json")))
-	}
-	if gcreds64 != "" {
-		decodedBytes, err := base64.StdEncoding.DecodeString(gcreds64)
-		if err != nil {
-			return err
-		}
-		if err := os.WriteFile(path.Join(tempDir, "creds.json"), decodedBytes, 0o600); err != nil {
 			return err
 		}
 		cmd.Env = append(cmd.Env, fmt.Sprintf("GOOGLE_APPLICATION_CREDENTIALS=%s", path.Join(tempDir, "creds.json")))

--- a/templates/resources/cluster.md.tmpl
+++ b/templates/resources/cluster.md.tmpl
@@ -49,7 +49,9 @@ To create a GCP BYOC cluster you must provide a GCP_PROJECT_ID and GOOGLE_CREDEN
 
 ### Azure BYOC
 
-To create a BYOC Azure cluster you must provide an AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TENANT_ID, and AZURE_SUBSCRIPTION_ID. Getting a Tenant ID [requires creating a subscription](https://learn.microsoft.com/en-us/azure/azure-portal/get-subscription-tenant-id). The account [must have fairly wide ranging permissions](https://docs.redpanda.com/redpanda-cloud/security/authorization/cloud-iam-policies-azure/) to create the necessary infrastructure.
+To create a BYOC Azure cluster you must provide Azure credentials, be logged in to the Azure CLI, or specify an Azure authentication method. This provider supports [the same authentication methods and environment variables as the official AzureRM provider](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/azure_cli). For example, to use a service principal and client certificate, you can pass the environment variables `ARM_CLIENT_ID`, `ARM_CLIENT_SECRET`, `ARM_TENANT_ID`, and `ARM_SUBSCRIPTION_ID`.
+
+The account [must have fairly wide ranging permissions](https://docs.redpanda.com/redpanda-cloud/security/authorization/cloud-iam-policies-azure/) to create the necessary infrastructure.
 
 {{ tffile "examples/byoc/azure/main.tf" }}
 


### PR DESCRIPTION
Fix for #196 

Adds support for authenticating with Azure via the Azure CLI, and should provide support for managed and workload identities as well.

I'd also suggest removing support for `AZURE_*` environment variables and standardizing on the same `ARM_*` variables used by the Terraform azurerm provider. I've left that out of this PR for the sake of getting CI to pass.