### PR TITLE
fix: add missing gcp cmr elements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ endef
 # Function to determine TF_CONFIG_DIR
 define GET_TF_CONFIG_DIR
 $(shell \
-    if [ "$(TEST_TYPE)" = "cluster" ] || [ "$(TEST_TYPE)" = "byoc"] || [ "$(TEST_TYPE)" = "byovpc" ]; then \
+    if [ "$(TEST_TYPE)" = "cluster" ] || [ "$(TEST_TYPE)" = "byoc" ] || [ "$(TEST_TYPE)" = "byovpc" ]; then \
         echo "examples/$(TEST_TYPE)/$(CLOUD_PROVIDER)"; \
     elif [ "$(TEST_TYPE)" = "datasource" ]; then \
         echo "examples/$(TEST_TYPE)/$(DATASOURCE_TEST_DIR)"; \

--- a/examples/byovpc/gcp/main.tf
+++ b/examples/byovpc/gcp/main.tf
@@ -14,6 +14,7 @@ module "redpanda_gcp" {
   unique_identifier = var.environment
   force_destroy_mgmt_bucket = var.environment == "dev" ? true : false
   network_project_id = var.project_id
+  force_destroy_cloud_storage_bucket = var.environment == "dev" ? true : false
 }
 
 # Redpanda resource group

--- a/redpanda/resources/cluster/data_cluster.go
+++ b/redpanda/resources/cluster/data_cluster.go
@@ -835,6 +835,109 @@ func datasourceClusterSchema() schema.Schema {
 							},
 						},
 					},
+					"gcp": schema.SingleNestedAttribute{
+						Computed: true,
+						Attributes: map[string]schema.Attribute{
+							"subnet": schema.SingleNestedAttribute{
+								Computed:    true,
+								Description: "GCP subnet where Redpanda cluster is deployed.",
+								Attributes: map[string]schema.Attribute{
+									"name": schema.StringAttribute{
+										Computed:    true,
+										Description: "Subnet name.",
+									},
+									"secondary_ipv4_range_pods": schema.SingleNestedAttribute{
+										Computed:    true,
+										Description: "Secondary IPv4 range for pods.",
+										Attributes: map[string]schema.Attribute{
+											"name": schema.StringAttribute{
+												Computed:    true,
+												Description: "Secondary IPv4 range name for pods.",
+											},
+										},
+									},
+									"secondary_ipv4_range_services": schema.SingleNestedAttribute{
+										Computed:    true,
+										Description: "Secondary IPv4 range for services.",
+										Attributes: map[string]schema.Attribute{
+											"name": schema.StringAttribute{
+												Computed:    true,
+												Description: "Secondary IPv4 range name for services.",
+											},
+										},
+									},
+									"k8s_master_ipv4_range": schema.StringAttribute{
+										Computed:    true,
+										Description: "Kubernetes Master IPv4 range, e.g. 10.0.0.0/24.",
+									},
+								},
+							},
+							"agent_service_account": schema.SingleNestedAttribute{
+								Computed:    true,
+								Description: "GCP service account for the agent.",
+								Attributes: map[string]schema.Attribute{
+									"email": schema.StringAttribute{
+										Computed:    true,
+										Description: "GCP service account email.",
+									},
+								},
+							},
+							"console_service_account": schema.SingleNestedAttribute{
+								Computed:    true,
+								Description: "GCP service account for Redpanda Console.",
+								Attributes: map[string]schema.Attribute{
+									"email": schema.StringAttribute{
+										Computed:    true,
+										Description: "GCP service account email.",
+									},
+								},
+							},
+							"connector_service_account": schema.SingleNestedAttribute{
+								Computed:    true,
+								Description: "GCP service account for managed connectors.",
+								Attributes: map[string]schema.Attribute{
+									"email": schema.StringAttribute{
+										Computed:    true,
+										Description: "GCP service account email.",
+									},
+								},
+							},
+							"redpanda_cluster_service_account": schema.SingleNestedAttribute{
+								Computed:    true,
+								Description: "GCP service account for the Redpanda cluster.",
+								Attributes: map[string]schema.Attribute{
+									"email": schema.StringAttribute{
+										Computed:    true,
+										Description: "GCP service account email.",
+									},
+								},
+							},
+							"gke_service_account": schema.SingleNestedAttribute{
+								Computed:    true,
+								Description: "GCP service account for GCP Kubernetes Engine (GKE).",
+								Attributes: map[string]schema.Attribute{
+									"email": schema.StringAttribute{
+										Computed:    true,
+										Description: "GCP service account email.",
+									},
+								},
+							},
+							"tiered_storage_bucket": schema.SingleNestedAttribute{
+								Computed:    true,
+								Description: "GCP storage bucket for Tiered storage.",
+								Attributes: map[string]schema.Attribute{
+									"name": schema.StringAttribute{
+										Computed:    true,
+										Description: "GCP storage bucket name.",
+									},
+								},
+							},
+							"psc_nat_subnet_name": schema.StringAttribute{
+								Computed:    true,
+								Description: "NAT subnet name if GCP Private Service Connect is enabled.",
+							},
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
Adds GCP CMR datasource elements in the cluster datasource schema that were missing and causing trouble. 

Tested the datasource element successfully. 