### PR TITLE
Update cidr.go - Invalid CIDR validation

### DIFF
--- a/redpanda/validators/cidr.go
+++ b/redpanda/validators/cidr.go
@@ -53,7 +53,7 @@ func (CIDRBlockValidator) ValidateString(ctx context.Context, req validator.Stri
 
 	// Validate CIDR block format if a value is provided
 	if !req.ConfigValue.IsNull() {
-		cidrRegex := regexp.MustCompile(`^(\d{1,3}\.){3}\d{1,3}/(\d{1,2})$`)
+		cidrRegex := regexp.MustCompile(`^(\d{1,3}\.){3}\d{1,3}\/(\d{1,2})$`)
 		if !cidrRegex.MatchString(req.ConfigValue.ValueString()) {
 			resp.Diagnostics.AddAttributeError(
 				req.Path,


### PR DESCRIPTION
When running terraform plan with a valid CIDR we get the following error. This is where the issue seems to be stemming form as this the backward slash `/` is not properly escaped. Using `10.0.0.0/16` for example will result in a compile error. 

```
davidyu@davidyu-MacBook-Pro aws % terraform plan
╷
│ Error: Invalid CIDR Block
│
│   with redpanda_network.test,
│   on main.tf line 64, in resource "redpanda_network" "test":
│   64:   cidr_block        = var.cidr_block
│
│ The value must be a valid CIDR block (e.g., 192.168.0.0/16)
```