### PR TITLE
Add IsUnknown guard for CIDR validation

### DIFF
--- a/redpanda/validators/cidr.go
+++ b/redpanda/validators/cidr.go
@@ -52,7 +52,7 @@ func (CIDRBlockValidator) ValidateString(ctx context.Context, req validator.Stri
 	}
 
 	// Validate CIDR block format if a value is provided
-	if !req.ConfigValue.IsNull() {
+	if !req.ConfigValue.IsUnknown() && !req.ConfigValue.IsNull() {
 		cidrRegex := regexp.MustCompile(`^(\d{1,3}\.){3}\d{1,3}/(\d{1,2})$`)
 		if !cidrRegex.MatchString(req.ConfigValue.ValueString()) {
 			resp.Diagnostics.AddAttributeError(


### PR DESCRIPTION
When using a variable for the `cidr_block` attribute in the network resource, validation will always fail due to the initial validation pass using an `Unknown` value. Without adding this guard, the value always gets interpreted as an empty string and fails the regex check.