### PR TITLE
Add GCP-related fields to the data model for network

### DIFF
--- a/redpanda/resources/network/data_network.go
+++ b/redpanda/resources/network/data_network.go
@@ -98,6 +98,29 @@ func datasourceNetworkSchema() schema.Schema {
 			"customer_managed_resources": schema.SingleNestedAttribute{
 				Computed: true,
 				Attributes: map[string]schema.Attribute{
+					"gcp": schema.SingleNestedAttribute{
+						Optional: true,
+						Computed: true,
+						Attributes: map[string]schema.Attribute{
+							"network_name": schema.StringAttribute{
+								Computed:    true,
+								Description: "Name of user-created network where the Redpanda cluster is deployed",
+							},
+							"network_project_id": schema.StringAttribute{
+								Computed:    true,
+								Description: "GCP project ID where the network is created",
+							},
+							"management_bucket": schema.SingleNestedAttribute{
+								Computed: true,
+								Attributes: map[string]schema.Attribute{
+									"name": schema.StringAttribute{
+										Required:    true,
+										Description: "GCP storage bucket name for storing the state of Redpanda cluster deployment",
+									},
+								},
+							},
+						},
+					},
 					"aws": schema.SingleNestedAttribute{
 						Optional: true,
 						Computed: true,


### PR DESCRIPTION
This adds some necessary fields to the data model of GCP. Currently using `data.redpanda_network` with the provider errors out with the cleaned up following error:

```
Expected framework type from provider logic:
    types.ObjectType[
        "aws":  types.ObjectType[
            "dynamodb_table":types.ObjectType[
                "arn":basetypes.StringType
            ],
            "management_bucket":types.ObjectType[
                "arn":basetypes.StringType
            ],
            "private_subnets":types.ObjectType[
                "arns":types.ListType[basetypes.StringType]
            ],
            "vpc":types.ObjectType[
                "arn":basetypes.StringType
            ]
        ]
    ]

...

Received framework type from provider logic:

types.ObjectType[
    "aws":types.ObjectType[
        "dynamodb_table":types.ObjectType[
            "arn":basetypes.StringType
        ],
        "management_bucket":types.ObjectType[
            "arn":basetypes.StringType
        ],
        "private_subnets":types.ObjectType[
            "arns":types.ListType[basetypes.StringType]
        ],
        "vpc":types.ObjectType[
            "arn":basetypes.StringType
        ]
    ],
    "gcp":types.ObjectType[
        "management_bucket":types.ObjectType[
            "name":basetypes.StringType
        ],
        "network_name":basetypes.StringType,
        "network_project_id":basetypes.StringType
    ]
]
```

This points to an underlying issue where the data schema doesn't match the object that we're actually returning, which has `gcp` attributes defined on it. The returned object definition is here: https://github.com/redpanda-data/terraform-provider-redpanda/blob/ff5412cf1c2b6850c98be0ee11e0e5c9ccdcaa46/redpanda/resources/network/cmr_object_definition.go#L12-L14