### PR TITLE
Fix Network Datasource CMR Issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,6 +224,9 @@ tf-apply:
 	elif grep -q "data \"redpanda_cluster\"" *.tf; then \
 		CLUSTER_ID=$$(echo "$$CLUSTER_INFO" | jq -r ".id"); \
 		terraform apply -auto-approve -var="cluster_id=$$CLUSTER_ID"; \
+	elif grep -q "data \"redpanda_network\"" *.tf; then \
+		CLUSTER_ID=$$(echo "$$CLUSTER_INFO" | jq -r ".id"); \
+		terraform apply -auto-approve -var="network_id=$$NETWORK_ID"; \
 	else \
 		echo "Error: No supported Redpanda cluster configuration found in Terraform files."; \
 		exit 1; \
@@ -277,6 +280,9 @@ test-destroy:
 	elif grep -q "data \"redpanda_cluster\"" *.tf; then \
 		terraform destroy -auto-approve \
 			-var="cluster_id=$$CLUSTER_ID"; \
+	elif grep -q "data \"redpanda_network\"" *.tf; then \
+		CLUSTER_ID=$$(echo "$$CLUSTER_INFO" | jq -r ".id"); \
+		terraform apply -auto-approve -var="network_id=$$NETWORK_ID"; \
 	else \
 		echo "Error: No supported Redpanda cluster configuration found in Terraform files."; \
 		exit 1; \

--- a/docs/data-sources/network.md
+++ b/docs/data-sources/network.md
@@ -32,6 +32,7 @@ Data source for a Redpanda Cloud network
 Optional:
 
 - `aws` (Attributes) (see [below for nested schema](#nestedatt--customer_managed_resources--aws))
+- `gcp` (Attributes) (see [below for nested schema](#nestedatt--customer_managed_resources--gcp))
 
 <a id="nestedatt--customer_managed_resources--aws"></a>
 ### Nested Schema for `customer_managed_resources.aws`
@@ -73,6 +74,24 @@ Required:
 Required:
 
 - `arn` (String) AWS VPC identifier
+
+
+
+<a id="nestedatt--customer_managed_resources--gcp"></a>
+### Nested Schema for `customer_managed_resources.gcp`
+
+Read-Only:
+
+- `management_bucket` (Attributes) (see [below for nested schema](#nestedatt--customer_managed_resources--gcp--management_bucket))
+- `network_name` (String) Name of user-created network where the Redpanda cluster is deployed
+- `network_project_id` (String) GCP project ID where the network is created
+
+<a id="nestedatt--customer_managed_resources--gcp--management_bucket"></a>
+### Nested Schema for `customer_managed_resources.gcp.management_bucket`
+
+Required:
+
+- `name` (String) GCP storage bucket name for storing the state of Redpanda cluster deployment
 
 ## Usage
 

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -25,7 +25,7 @@ Enables the provisioning and management of Redpanda clusters on AWS and GCP. A c
 
 ### Optional
 
-- `allow_deletion` (Boolean) Allows deletion of the cluster. Defaults to true. Should probably be set to false for production use.
+- `allow_deletion` (Boolean) Allows deletion of the cluster. Defaults to false.
 - `aws_private_link` (Attributes) AWS PrivateLink configuration. (see [below for nested schema](#nestedatt--aws_private_link))
 - `azure_private_link` (Attributes) Azure Private Link configuration. (see [below for nested schema](#nestedatt--azure_private_link))
 - `cloud_provider` (String) Cloud provider where resources are created.
@@ -1520,14 +1520,13 @@ provider "redpanda" {}
 
 # Use the Redpanda GCP BYOVPC module
 module "redpanda_gcp" {
-  source = "github.com/redpanda-data/terraform-gcp-redpanda-byovpc.git?ref=fix-cross-var-error"
+  source  = "redpanda-data/redpanda-byovpc/gcp"
   service_project_id        = var.project_id
   region            = var.region
   unique_identifier = var.environment
   force_destroy_mgmt_bucket = var.environment == "dev" ? true : false
   force_destroy_cloud_storage_bucket =  var.environment == "dev" ? true : false
   network_project_id = var.project_id
-  force_destroy_cloud_storage_bucket = var.environment == "dev" ? true : false
 }
 
 # Redpanda resource group

--- a/docs/resources/topic.md
+++ b/docs/resources/topic.md
@@ -23,7 +23,7 @@ Creates a topic in a Redpanda Cluster
 
 - `allow_deletion` (Boolean) Indicates whether the topic can be deleted.
 - `configuration` (Map of String) A map of string key/value pairs of topic configurations.
-- `partition_count` (Number) The number of partitions for the topic. This determines how the data is distributed across brokers. Increases are fully supported without data loss, decreases will result in an error and should be accomplished by creating a new topic and migrating the data.
+- `partition_count` (Number) The number of partitions for the topic. This determines how the data is distributed across brokers. Increases are fully supported without data loss. Decreases will destroy and recreate the topic if allow_deletion is set to true (defaults to false).
 - `replication_factor` (Number) The replication factor for the topic, which defines how many copies of the data are kept across different brokers for fault tolerance.
 
 ### Read-Only

--- a/examples/byovpc/gcp/main.tf
+++ b/examples/byovpc/gcp/main.tf
@@ -8,14 +8,13 @@ provider "redpanda" {}
 
 # Use the Redpanda GCP BYOVPC module
 module "redpanda_gcp" {
-  source = "github.com/redpanda-data/terraform-gcp-redpanda-byovpc.git?ref=fix-cross-var-error"
+  source  = "redpanda-data/redpanda-byovpc/gcp"
   service_project_id        = var.project_id
   region            = var.region
   unique_identifier = var.environment
   force_destroy_mgmt_bucket = var.environment == "dev" ? true : false
   force_destroy_cloud_storage_bucket =  var.environment == "dev" ? true : false
   network_project_id = var.project_id
-  force_destroy_cloud_storage_bucket = var.environment == "dev" ? true : false
 }
 
 # Redpanda resource group

--- a/examples/datasource/network/main.tf
+++ b/examples/datasource/network/main.tf
@@ -1,0 +1,22 @@
+provider "redpanda" {}
+
+variable "network_id" {
+  default = ""
+}
+
+data "redpanda_network" "test" {
+  id = var.network_id
+}
+
+output "network" {
+  value = data.redpanda_network.test
+}
+
+output "cloud_provider" {
+  value = data.redpanda_network.test.cloud_provider
+}
+
+output "cmr" {
+  value = data.redpanda_network.test.customer_managed_resources
+}
+

--- a/redpanda/redpanda.go
+++ b/redpanda/redpanda.go
@@ -300,7 +300,9 @@ func (r *Redpanda) Configure(ctx context.Context, request provider.ConfigureRequ
 		os.Getenv("GOOGLE_PROJECT"),
 		os.Getenv("GOOGLE_CLOUD_PROJECT"),
 		os.Getenv("GCLOUD_PROJECT"),
-		os.Getenv("CLOUDSDK_CORE_PROJECT"))
+		os.Getenv("CLOUDSDK_CORE_PROJECT"),
+		os.Getenv("GOOGLE_PROJECT_ID"),
+		os.Getenv("GCP_PROJECT_ID"))
 	azureClientID := firstNonEmptyString(
 		conf.AzureClientID.ValueString(),
 		os.Getenv("AZURE_CLIENT_ID"),

--- a/redpanda/resources/cluster/schema_resource.go
+++ b/redpanda/resources/cluster/schema_resource.go
@@ -75,7 +75,7 @@ func resourceClusterSchema() schema.Schema {
 			},
 			"allow_deletion": schema.BoolAttribute{
 				Optional:    true,
-				Description: "Allows deletion of the cluster. Defaults to true. Should probably be set to false for production use.",
+				Description: "Allows deletion of the cluster. Defaults to false.",
 			},
 			"tags": schema.MapAttribute{
 				Optional:      true,

--- a/redpanda/resources/network/data_network.go
+++ b/redpanda/resources/network/data_network.go
@@ -180,7 +180,7 @@ func (n *DataSourceNetwork) Read(ctx context.Context, req datasource.ReadRequest
 		resp.Diagnostics.AddError(fmt.Sprintf("failed to read network %s", model.ID.ValueString()), utils.DeserializeGrpcError(err))
 		return
 	}
-	m, d := generateModel(model.CloudProvider.ValueString(), nw, resp.Diagnostics)
+	m, d := generateModel(utils.CloudProviderToString(nw.CloudProvider), nw, resp.Diagnostics)
 	if d.HasError() {
 		resp.Diagnostics = append(resp.Diagnostics, d...)
 		return

--- a/redpanda/resources/network/network.go
+++ b/redpanda/resources/network/network.go
@@ -41,11 +41,11 @@ func generateModel(cloudProvider string, nw *controlplanev1.Network, diags diag.
 	if nw.GetCidrBlock() != "" && nw.CidrBlock != "0.0.0.0/0" {
 		output.CidrBlock = types.StringValue(nw.GetCidrBlock())
 	}
+
+	output.CustomerManagedResources = types.ObjectNull(cmrType)
 	if nw.HasCustomerManagedResources() {
-		output.CustomerManagedResources = types.ObjectNull(cmrType)
 		return generateModelCMR(cloudProvider, nw, output, diags)
 	}
-	output.CustomerManagedResources = types.ObjectNull(cmrType)
 	return output, diags
 }
 

--- a/redpanda/resources/network/network_test.go
+++ b/redpanda/resources/network/network_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/redpanda-data/terraform-provider-redpanda/redpanda/models"
 	"github.com/stretchr/testify/assert"
 )
@@ -190,6 +191,64 @@ func TestGenerateNetworkCMR(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "successful gcp config",
+			model: models.Network{
+				CloudProvider: types.StringValue("gcp"),
+				CustomerManagedResources: types.ObjectValueMust(
+					map[string]attr.Type{
+						"gcp": types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"network_name":       types.StringType,
+								"network_project_id": types.StringType,
+								"management_bucket": types.ObjectType{
+									AttrTypes: map[string]attr.Type{
+										"name": types.StringType,
+									},
+								},
+							},
+						},
+					},
+					map[string]attr.Value{
+						"gcp": types.ObjectValueMust(
+							map[string]attr.Type{
+								"network_name":       types.StringType,
+								"network_project_id": types.StringType,
+								"management_bucket": types.ObjectType{
+									AttrTypes: map[string]attr.Type{
+										"name": types.StringType,
+									},
+								},
+							},
+							map[string]attr.Value{
+								"network_name":       types.StringValue("test-network"),
+								"network_project_id": types.StringValue("test-project"),
+								"management_bucket": types.ObjectValueMust(
+									map[string]attr.Type{
+										"name": types.StringType,
+									},
+									map[string]attr.Value{
+										"name": types.StringValue("test-bucket"),
+									},
+								),
+							},
+						),
+					},
+				),
+			},
+			want: &controlplanev1.Network_CustomerManagedResources{
+				CloudProvider: &controlplanev1.Network_CustomerManagedResources_Gcp{
+					Gcp: &controlplanev1.Network_CustomerManagedResources_GCP{
+						NetworkName:      "test-network",
+						NetworkProjectId: "test-project",
+						ManagementBucket: &controlplanev1.CustomerManagedGoogleCloudStorageBucket{
+							Name: "test-bucket",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "null customer managed resources",
 			model: models.Network{
 				CloudProvider:            types.StringValue("aws"),
@@ -217,7 +276,25 @@ func TestGenerateNetworkCMR(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "gcp provider",
+			name: "missing gcp object",
+			model: models.Network{
+				CloudProvider: types.StringValue("gcp"),
+				CustomerManagedResources: types.ObjectValueMust(
+					map[string]attr.Type{
+						"gcp": types.ObjectType{
+							AttrTypes: map[string]attr.Type{},
+						},
+					},
+					map[string]attr.Value{
+						"gcp": types.ObjectNull(map[string]attr.Type{}),
+					},
+				),
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "gcp provider with null cmr",
 			model: models.Network{
 				CloudProvider:            types.StringValue("gcp"),
 				CustomerManagedResources: types.ObjectNull(cmrType),
@@ -245,6 +322,283 @@ func TestGenerateNetworkCMR(t *testing.T) {
 			}
 
 			assert.Equal(t, tt.want, got, "unexpected result from generateNetworkCMR()")
+		})
+	}
+}
+
+func TestGenerateModelGCPCMR(t *testing.T) {
+	tests := []struct {
+		name    string
+		gcpData *controlplanev1.Network_CustomerManagedResources_GCP
+		want    basetypes.ObjectValue
+		wantErr bool
+	}{
+		{
+			name: "with all fields populated",
+			gcpData: &controlplanev1.Network_CustomerManagedResources_GCP{
+				NetworkName:      "test-network",
+				NetworkProjectId: "test-project",
+				ManagementBucket: &controlplanev1.CustomerManagedGoogleCloudStorageBucket{
+					Name: "test-bucket",
+				},
+			},
+			want: types.ObjectValueMust(
+				gcpType,
+				map[string]attr.Value{
+					"network_name":       types.StringValue("test-network"),
+					"network_project_id": types.StringValue("test-project"),
+					"management_bucket": types.ObjectValueMust(
+						gcpBucketType,
+						map[string]attr.Value{
+							"name": types.StringValue("test-bucket"),
+						},
+					),
+				},
+			),
+			wantErr: false,
+		},
+		{
+			name: "with missing management bucket",
+			gcpData: &controlplanev1.Network_CustomerManagedResources_GCP{
+				NetworkName:      "test-network",
+				NetworkProjectId: "test-project",
+			},
+			want: types.ObjectValueMust(
+				gcpType,
+				map[string]attr.Value{
+					"network_name":       types.StringValue("test-network"),
+					"network_project_id": types.StringValue("test-project"),
+					"management_bucket":  types.ObjectNull(gcpBucketType),
+				},
+			),
+			wantErr: false,
+		},
+		{
+			name: "with only network name",
+			gcpData: &controlplanev1.Network_CustomerManagedResources_GCP{
+				NetworkName: "test-network",
+			},
+			want: types.ObjectValueMust(
+				gcpType,
+				map[string]attr.Value{
+					"network_name":       types.StringValue("test-network"),
+					"network_project_id": types.StringNull(),
+					"management_bucket":  types.ObjectNull(gcpBucketType),
+				},
+			),
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			diags := diag.Diagnostics{}
+			got, gotDiags := generateModelGCPCMR(tt.gcpData, diags)
+
+			if tt.wantErr {
+				if !gotDiags.HasError() {
+					t.Error("generateModelGCPCMR() expected error but got none")
+				}
+				return
+			}
+
+			if gotDiags.HasError() {
+				t.Errorf("generateModelGCPCMR() unexpected error: %v", gotDiags)
+				return
+			}
+
+			assert.Equal(t, tt.want, got, "unexpected result from generateModelGCPCMR()")
+		})
+	}
+}
+
+func TestGenerateModel(t *testing.T) {
+	tests := []struct {
+		name          string
+		cloudProvider string
+		network       *controlplanev1.Network
+		want          *models.Network
+		wantErr       bool
+	}{
+		{
+			name:          "network with AWS CMR",
+			cloudProvider: "aws",
+			network: &controlplanev1.Network{
+				Id:              "test-id",
+				Name:            "test-name",
+				Region:          "us-east-2",
+				CloudProvider:   controlplanev1.CloudProvider_CLOUD_PROVIDER_AWS,
+				ClusterType:     controlplanev1.Cluster_TYPE_BYOC,
+				ResourceGroupId: "resource-group-id",
+				CidrBlock:       "10.0.0.0/16",
+				CustomerManagedResources: &controlplanev1.Network_CustomerManagedResources{
+					CloudProvider: &controlplanev1.Network_CustomerManagedResources_Aws{
+						Aws: &controlplanev1.Network_CustomerManagedResources_AWS{
+							ManagementBucket: &controlplanev1.CustomerManagedAWSCloudStorageBucket{
+								Arn: "test-bucket-arn",
+							},
+							DynamodbTable: &controlplanev1.CustomerManagedDynamoDBTable{
+								Arn: "test-dynamo-arn",
+							},
+							Vpc: &controlplanev1.CustomerManagedAWSVPC{
+								Arn: "test-vpc-arn",
+							},
+							PrivateSubnets: &controlplanev1.CustomerManagedAWSSubnets{
+								Arns: []string{"subnet-1", "subnet-2"},
+							},
+						},
+					},
+				},
+			},
+			want: &models.Network{
+				ID:              types.StringValue("test-id"),
+				Name:            types.StringValue("test-name"),
+				Region:          types.StringValue("us-east-2"),
+				CloudProvider:   types.StringValue("aws"),
+				ClusterType:     types.StringValue("byoc"),
+				ResourceGroupID: types.StringValue("resource-group-id"),
+				CidrBlock:       types.StringValue("10.0.0.0/16"),
+				CustomerManagedResources: types.ObjectValueMust(
+					cmrType,
+					map[string]attr.Value{
+						"aws": types.ObjectValueMust(
+							awsType,
+							map[string]attr.Value{
+								"management_bucket": types.ObjectValueMust(
+									singleElementContainer,
+									map[string]attr.Value{
+										"arn": types.StringValue("test-bucket-arn"),
+									},
+								),
+								"dynamodb_table": types.ObjectValueMust(
+									singleElementContainer,
+									map[string]attr.Value{
+										"arn": types.StringValue("test-dynamo-arn"),
+									},
+								),
+								"vpc": types.ObjectValueMust(
+									singleElementContainer,
+									map[string]attr.Value{
+										"arn": types.StringValue("test-vpc-arn"),
+									},
+								),
+								"private_subnets": types.ObjectValueMust(
+									multiElementContainer,
+									map[string]attr.Value{
+										"arns": types.ListValueMust(
+											types.StringType,
+											[]attr.Value{
+												types.StringValue("subnet-1"),
+												types.StringValue("subnet-2"),
+											},
+										),
+									},
+								),
+							},
+						),
+						"gcp": types.ObjectNull(gcpType),
+					},
+				),
+			},
+			wantErr: false,
+		},
+		{
+			name:          "network with GCP CMR",
+			cloudProvider: "gcp",
+			network: &controlplanev1.Network{
+				Id:              "test-id",
+				Name:            "test-name",
+				Region:          "us-central1",
+				CloudProvider:   controlplanev1.CloudProvider_CLOUD_PROVIDER_GCP,
+				ClusterType:     controlplanev1.Cluster_TYPE_BYOC,
+				ResourceGroupId: "resource-group-id",
+				CidrBlock:       "10.0.0.0/16",
+				CustomerManagedResources: &controlplanev1.Network_CustomerManagedResources{
+					CloudProvider: &controlplanev1.Network_CustomerManagedResources_Gcp{
+						Gcp: &controlplanev1.Network_CustomerManagedResources_GCP{
+							NetworkName:      "test-network",
+							NetworkProjectId: "test-project",
+							ManagementBucket: &controlplanev1.CustomerManagedGoogleCloudStorageBucket{
+								Name: "test-bucket",
+							},
+						},
+					},
+				},
+			},
+			want: &models.Network{
+				ID:              types.StringValue("test-id"),
+				Name:            types.StringValue("test-name"),
+				Region:          types.StringValue("us-central1"),
+				CloudProvider:   types.StringValue("gcp"),
+				ClusterType:     types.StringValue("byoc"),
+				ResourceGroupID: types.StringValue("resource-group-id"),
+				CidrBlock:       types.StringValue("10.0.0.0/16"),
+				CustomerManagedResources: types.ObjectValueMust(
+					cmrType,
+					map[string]attr.Value{
+						"gcp": types.ObjectValueMust(
+							gcpType,
+							map[string]attr.Value{
+								"network_name":       types.StringValue("test-network"),
+								"network_project_id": types.StringValue("test-project"),
+								"management_bucket": types.ObjectValueMust(
+									gcpBucketType,
+									map[string]attr.Value{
+										"name": types.StringValue("test-bucket"),
+									},
+								),
+							},
+						),
+						"aws": types.ObjectNull(awsType),
+					},
+				),
+			},
+			wantErr: false,
+		},
+		{
+			name:          "network without CMR",
+			cloudProvider: "aws",
+			network: &controlplanev1.Network{
+				Id:              "test-id",
+				Name:            "test-name",
+				Region:          "us-east-2",
+				CloudProvider:   controlplanev1.CloudProvider_CLOUD_PROVIDER_AWS,
+				ClusterType:     controlplanev1.Cluster_TYPE_DEDICATED,
+				ResourceGroupId: "resource-group-id",
+				CidrBlock:       "10.0.0.0/16",
+			},
+			want: &models.Network{
+				ID:                       types.StringValue("test-id"),
+				Name:                     types.StringValue("test-name"),
+				Region:                   types.StringValue("us-east-2"),
+				CloudProvider:            types.StringValue("aws"),
+				ClusterType:              types.StringValue("dedicated"),
+				ResourceGroupID:          types.StringValue("resource-group-id"),
+				CidrBlock:                types.StringValue("10.0.0.0/16"),
+				CustomerManagedResources: types.ObjectNull(cmrType),
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			diags := diag.Diagnostics{}
+			got, gotDiags := generateModel(tt.cloudProvider, tt.network, diags)
+
+			if tt.wantErr {
+				if !gotDiags.HasError() {
+					t.Error("generateModel() expected error but got none")
+				}
+				return
+			}
+
+			if gotDiags.HasError() {
+				t.Errorf("generateModel() unexpected error: %v", gotDiags)
+				return
+			}
+
+			assert.Equal(t, tt.want, got, "unexpected result from generateModel()")
 		})
 	}
 }


### PR DESCRIPTION
Cloud provider was being incorrectly set in the call to generate model from the model instead of from the network response. As the user cannot provide cloud_provider in the datasource declaration model will likely always have a null value for cloud_provider. This meant that the generate_model function was skipping the GCP element and continuing to the default response (generating a null cmr object) which was incorrect. 

The fix was to pull the relevant cloud_provider value from the API response and use that. I've verified that everything works as intended and added an example. I will come back and add CI for this when I find a good long running byovpc network to take advantage of it. 