### PR TITLE
Allow modifying Kafka Connect

### DIFF
--- a/redpanda/resources/cluster/model_to_proto.go
+++ b/redpanda/resources/cluster/model_to_proto.go
@@ -512,11 +512,6 @@ func getKafkaConnectConfig(_ context.Context, connect types.Object, diags diag.D
 		diags.Append(d...)
 		return nil, diags
 	}
-	if !enabled {
-		// TODO: remove when cloud fixes this bug
-		return nil, diags
-	}
-
 	return &controlplanev1.KafkaConnect{
 		Enabled: enabled,
 	}, diags


### PR DESCRIPTION
During the march to 1.0.0 Kafka Connect's return was bugged which caused innumerable issues for the provider necessitating the disabling of its management. This bug has now been resolved and so we no longer need this little piece of code which did so much. 