### PR TITLE
cluster: add support for cluster_configuration

### DIFF
--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -23,6 +23,7 @@ Data source for a Redpanda Cloud cluster
 - `azure_private_link` (Attributes) Azure Private Link configuration. (see [below for nested schema](#nestedatt--azure_private_link))
 - `cloud_provider` (String) Cloud provider where resources are created.
 - `cluster_api_url` (String) The URL of the cluster API.
+- `cluster_configuration` (Attributes) Configuration for the cluster. (see [below for nested schema](#nestedatt--cluster_configuration))
 - `cluster_type` (String) Cluster type. Type is immutable and can only be set on cluster creation.
 - `connection_type` (String) Cluster connection type. Private clusters are not exposed to the internet. For BYOC clusters, Private is best-practice.
 - `created_at` (String) Timestamp when the cluster was created.
@@ -143,6 +144,14 @@ Read-Only:
 - `status` (String) Status of the endpoint connection.
 
 
+
+
+<a id="nestedatt--cluster_configuration"></a>
+### Nested Schema for `cluster_configuration`
+
+Read-Only:
+
+- `custom_properties_json` (String) Custom properties for the cluster in JSON format.
 
 
 <a id="nestedatt--customer_managed_resources"></a>

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -29,6 +29,7 @@ Enables the provisioning and management of Redpanda clusters on AWS and GCP. A c
 - `aws_private_link` (Attributes) AWS PrivateLink configuration. (see [below for nested schema](#nestedatt--aws_private_link))
 - `azure_private_link` (Attributes) Azure Private Link configuration. (see [below for nested schema](#nestedatt--azure_private_link))
 - `cloud_provider` (String) Cloud provider where resources are created.
+- `cluster_configuration` (Attributes) Configuration for the cluster. (see [below for nested schema](#nestedatt--cluster_configuration))
 - `customer_managed_resources` (Attributes) Customer managed resources configuration for the cluster. (see [below for nested schema](#nestedatt--customer_managed_resources))
 - `gcp_global_access_enabled` (Boolean) If true, GCP global access is enabled.
 - `gcp_private_service_connect` (Attributes) GCP Private Service Connect configuration. (see [below for nested schema](#nestedatt--gcp_private_service_connect))
@@ -154,6 +155,14 @@ Read-Only:
 - `status` (String) Status of the endpoint connection.
 
 
+
+
+<a id="nestedatt--cluster_configuration"></a>
+### Nested Schema for `cluster_configuration`
+
+Optional:
+
+- `custom_properties_json` (String) Custom properties for the cluster in JSON format.
 
 
 <a id="nestedatt--customer_managed_resources"></a>

--- a/redpanda/models/cluster/object_definitions.go
+++ b/redpanda/models/cluster/object_definitions.go
@@ -159,6 +159,12 @@ func getMtlsType() map[string]attr.Type {
 	}
 }
 
+func getClusterConfigurationType() map[string]attr.Type {
+	return map[string]attr.Type{
+		"custom_properties_json": types.StringType,
+	}
+}
+
 func getHTTPProxyType() map[string]attr.Type {
 	return map[string]attr.Type{
 		"mtls": types.ObjectType{AttrTypes: getMtlsType()},

--- a/redpanda/resources/cluster/schema_datasource.go
+++ b/redpanda/resources/cluster/schema_datasource.go
@@ -74,6 +74,16 @@ func datasourceClusterSchema() schema.Schema {
 				Computed:    true,
 				Description: "Timestamp when the cluster was created.",
 			},
+			"cluster_configuration": schema.SingleNestedAttribute{
+				Computed:    true,
+				Description: "Configuration for the cluster.",
+				Attributes: map[string]schema.Attribute{
+					"custom_properties_json": schema.StringAttribute{
+						Computed:    true,
+						Description: "Custom properties for the cluster in JSON format.",
+					},
+				},
+			},
 			"kafka_api": schema.SingleNestedAttribute{
 				Computed:    true,
 				Description: "Cluster's Kafka API properties.",

--- a/redpanda/resources/cluster/schema_resource.go
+++ b/redpanda/resources/cluster/schema_resource.go
@@ -113,6 +113,18 @@ func resourceClusterSchema() schema.Schema {
 				Description:   "The URL of the cluster API.",
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
+			"cluster_configuration": schema.SingleNestedAttribute{
+				Optional:      true,
+				Computed:      true,
+				Description:   "Configuration for the cluster.",
+				PlanModifiers: []planmodifier.Object{objectplanmodifier.UseStateForUnknown()},
+				Attributes: map[string]schema.Attribute{
+					"custom_properties_json": schema.StringAttribute{
+						Optional:    true,
+						Description: "Custom properties for the cluster in JSON format.",
+					},
+				},
+			},
 			"kafka_api": schema.SingleNestedAttribute{
 				Optional:      true,
 				Computed:      true,


### PR DESCRIPTION
Adds in Cluster Configuration support. Also adds the first take at a consistency test comparing plan and apply -- because most of the sources of provider inconsistency are because the apply phase returns one thing and the plan phase returns anotehr -- as part of the process. This is currently a proof of concept, I hope to generate something more robust and automated for comparison purposes in future (say taking advantage of the golden file testing from k8s operator and outputting the plan and apply models/proto structures to yaml files for comparison). 