### PR TITLE
feat: add redpanda_role_assignment resource for RBAC management

### DIFF
--- a/docs/resources/role_assignment.md
+++ b/docs/resources/role_assignment.md
@@ -1,0 +1,119 @@
+---
+page_title: "redpanda_role_assignment Resource - terraform-provider-redpanda"
+subcategory: ""
+description: |-
+  A role assignment is used for attaching one user to a role.
+---
+
+# redpanda_role_assignment (Resource)
+
+Assigns an existing Redpanda role to a principal. Resource ID format: `{role_name}:{principal}`
+
+## Example Usage
+
+```terraform
+provider "redpanda" {}
+
+resource "redpanda_resource_group" "test" {
+  name = var.resource_group_name
+}
+
+resource "redpanda_network" "test" {
+  name              = var.network_name
+  resource_group_id = redpanda_resource_group.test.id
+  cloud_provider    = var.cloud_provider
+  region            = var.region
+  cluster_type      = "dedicated"
+  cidr_block        = "10.0.0.0/20"
+}
+
+resource "redpanda_cluster" "test" {
+  name              = var.cluster_name
+  network_id        = redpanda_network.test.id
+  cloud_provider    = var.cloud_provider
+  region            = var.region
+  cluster_type      = "dedicated"
+  connection_type   = "public"
+  throughput_tier   = var.throughput_tier
+  zones             = var.zones
+  allow_deletion    = true
+  tags = {
+    "key" = "value"
+  }
+}
+
+# Create a user
+resource "redpanda_user" "test_user" {
+  name            = "test-user"
+  password        = "test-password"
+  mechanism       = "scram-sha-256"
+  cluster_api_url = redpanda_cluster.test.cluster_api_url
+}
+
+# Create a role (note: this would need to be created via rpk CLI separately)
+# rpk security role create test-role
+
+# Assign the role to the user
+resource "redpanda_role_assignment" "test" {
+  role_name       = "test-role"
+  principal       = redpanda_user.test_user.id
+  cluster_api_url = redpanda_cluster.test.cluster_api_url
+}
+
+variable "resource_group_name" {
+  default = "testname"
+}
+
+variable "network_name" {
+  default = "testname"
+}
+
+variable "cluster_name" {
+  default = "testname"
+}
+
+variable "region" {
+  default = "us-east-2"
+}
+
+variable "zones" {
+  default = ["use2-az1", "use2-az2", "use2-az3"]
+}
+
+variable "cloud_provider" {
+  default = "aws"
+}
+
+variable "throughput_tier" {
+  default = "tier-1-aws-v2-arm"
+}
+```
+
+## Schema
+
+### Required
+
+- `cluster_api_url` (String) The cluster API URL. Changing this will prevent deletion of the resource on the existing cluster
+- `principal` (String) The principal to assign the role to. Specify just the username (e.g., `"john.doe"`)
+- `role_name` (String) The name of the role to assign
+
+### Read-Only
+
+- `id` (String) The ID of this resource. Format: `{role_name}:{principal}`
+
+## Import
+
+Role assignments can be imported using the format `role_name:principal`:
+
+```shell
+terraform import redpanda_role_assignment.test "test-role:test-user"
+```
+
+Note: The `cluster_api_url` must be specified in your Terraform configuration. The import will validate the role assignment exists during the next `terraform plan` or `terraform apply`.
+
+## Notes
+
+- The role must already exist before it can be assigned. Roles are typically created using `rpk security role create` or through the Redpanda Console.
+- The principal should be specified as just the username (e.g., `"john.doe"`). The `User:` prefix is not needed and will be automatically stripped if provided.
+- Role assignments are atomic operations - you cannot update an existing assignment. To change a role assignment, delete and recreate the resource.
+- The resource uses the Redpanda gRPC SecurityService (via console endpoint) for role management operations.

--- a/redpanda/models/role_assignment.go
+++ b/redpanda/models/role_assignment.go
@@ -1,0 +1,26 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package models
+
+import "github.com/hashicorp/terraform-plugin-framework/types"
+
+// RoleAssignment defines the structure for role assignment configuration settings parsed from HCL.
+type RoleAssignment struct {
+	RoleName      types.String `tfsdk:"role_name"`
+	Principal     types.String `tfsdk:"principal"`
+	ClusterAPIURL types.String `tfsdk:"cluster_api_url"`
+	ID            types.String `tfsdk:"id"`
+}

--- a/redpanda/redpanda.go
+++ b/redpanda/redpanda.go
@@ -41,6 +41,7 @@ import (
 	"github.com/redpanda-data/terraform-provider-redpanda/redpanda/resources/region"
 	"github.com/redpanda-data/terraform-provider-redpanda/redpanda/resources/regions"
 	"github.com/redpanda-data/terraform-provider-redpanda/redpanda/resources/resourcegroup"
+	"github.com/redpanda-data/terraform-provider-redpanda/redpanda/resources/roleassignment"
 	"github.com/redpanda-data/terraform-provider-redpanda/redpanda/resources/serverlesscluster"
 	"github.com/redpanda-data/terraform-provider-redpanda/redpanda/resources/serverlessregions"
 	"github.com/redpanda-data/terraform-provider-redpanda/redpanda/resources/throughputtiers"
@@ -419,5 +420,6 @@ func (*Redpanda) Resources(_ context.Context) []func() resource.Resource {
 		func() resource.Resource { return &acl.ACL{} },
 		func() resource.Resource { return &user.User{} },
 		func() resource.Resource { return &topic.Topic{} },
+		func() resource.Resource { return &roleassignment.RoleAssignment{} },
 	}
 }

--- a/redpanda/resources/roleassignment/resource_role_assignment.go
+++ b/redpanda/resources/roleassignment/resource_role_assignment.go
@@ -1,0 +1,330 @@
+package roleassignment
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"buf.build/gen/go/redpandadata/dataplane/grpc/go/redpanda/api/console/v1alpha1/consolev1alpha1grpc"
+	consolev1alpha1 "buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go/redpanda/api/console/v1alpha1"
+	dataplanev1 "buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go/redpanda/api/dataplane/v1"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/redpanda-data/terraform-provider-redpanda/redpanda/cloud"
+	"github.com/redpanda-data/terraform-provider-redpanda/redpanda/config"
+	"github.com/redpanda-data/terraform-provider-redpanda/redpanda/models"
+	"github.com/redpanda-data/terraform-provider-redpanda/redpanda/utils"
+	"google.golang.org/grpc"
+)
+
+// RoleAssignment implements the resource interface for role assignments.
+type RoleAssignment struct {
+	resData        config.Resource
+	SecurityClient consolev1alpha1grpc.SecurityServiceClient
+	dataplaneConn  *grpc.ClientConn
+}
+
+// NewRoleAssignment creates a new instance of the role assignment resource.
+func NewRoleAssignment() resource.Resource {
+	return &RoleAssignment{}
+}
+
+// Metadata returns the metadata for the role assignment resource.
+func (r *RoleAssignment) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_role_assignment"
+}
+
+// Schema returns the schema for the role assignment resource.
+func (r *RoleAssignment) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Assigns existing Redpanda roles to principals. Requires an existing role and user.",
+		Attributes: map[string]schema.Attribute{
+			"role_name": schema.StringAttribute{
+				MarkdownDescription: "The name of the role to assign.",
+				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"principal": schema.StringAttribute{
+				MarkdownDescription: "The principal (username) to assign the role to. Format: just the username (e.g., 'john.doe').",
+				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"cluster_api_url": schema.StringAttribute{
+				MarkdownDescription: "The API URL of the cluster where the role assignment should be made.",
+				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"id": schema.StringAttribute{
+				MarkdownDescription: "Unique identifier for the role assignment in the format '{role_name}:{principal}'.",
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+// Configure configures the role assignment resource.
+func (r *RoleAssignment) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	resData, ok := req.ProviderData.(config.Resource)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Resource Configure Type", fmt.Sprintf("Expected config.Resource, got: %T.", req.ProviderData))
+		return
+	}
+	r.resData = resData
+}
+
+// Create creates a new role assignment.
+func (r *RoleAssignment) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var model models.RoleAssignment
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &model)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	roleName := model.RoleName.ValueString()
+	principal := normalizePrincipal(model.Principal.ValueString())
+	clusterAPIURL := model.ClusterAPIURL.ValueString()
+
+	if err := r.createSecurityClient(ctx, clusterAPIURL); err != nil {
+		resp.Diagnostics.AddError("Failed to create SecurityService client", utils.DeserializeGrpcError(err))
+		return
+	}
+	defer r.dataplaneConn.Close()
+
+	// Add the principal to the role
+	dataplaneReq := &dataplanev1.UpdateRoleMembershipRequest{
+		RoleName: roleName,
+		Add:      []*dataplanev1.RoleMembership{{Principal: principal}},
+	}
+	consoleReq := &consolev1alpha1.UpdateRoleMembershipRequest{
+		Request: dataplaneReq,
+	}
+
+	_, err := r.SecurityClient.UpdateRoleMembership(ctx, consoleReq)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to assign role", utils.DeserializeGrpcError(err))
+		return
+	}
+
+	// Store the normalized principal and set the ID
+	model.Principal = types.StringValue(principal)
+	model.ID = types.StringValue(fmt.Sprintf("%s:%s", roleName, principal))
+	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+}
+
+// Read reads the role assignment state
+func (r *RoleAssignment) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var model models.RoleAssignment
+	resp.Diagnostics.Append(req.State.Get(ctx, &model)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	roleName := model.RoleName.ValueString()
+	principal := model.Principal.ValueString() // Already normalized when stored
+	clusterAPIURL := model.ClusterAPIURL.ValueString()
+
+	// Validate required fields
+	if roleName == "" || principal == "" {
+		resp.Diagnostics.AddError(
+			"Invalid state data",
+			fmt.Sprintf("Missing required fields - role_name: '%s', principal: '%s'", roleName, principal),
+		)
+		return
+	}
+
+	// If cluster_api_url is empty (e.g., during import), skip the API check
+	// The next plan/apply will validate the resource exists
+	if clusterAPIURL == "" {
+		tflog.Info(ctx, "Skipping API check due to empty cluster_api_url (likely during import)")
+		resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+		return
+	}
+
+	// Create SecurityService client and verify the role assignment exists
+	if err := r.createSecurityClient(ctx, clusterAPIURL); err != nil {
+		resp.Diagnostics.AddError("Failed to create SecurityService client", utils.DeserializeGrpcError(err))
+		return
+	}
+	defer r.dataplaneConn.Close()
+
+	exists, err := r.roleAssignmentExists(ctx, roleName, principal)
+	if err != nil {
+		// Don't remove from state on API errors - just fail the read
+		resp.Diagnostics.AddError(
+			"Failed to verify role assignment",
+			fmt.Sprintf("Could not check if role assignment %s:%s exists: %s", roleName, principal, utils.DeserializeGrpcError(err)),
+		)
+		return
+	}
+
+	if !exists {
+		tflog.Warn(ctx, "Role assignment not found, removing from state", map[string]any{
+			"role_name": roleName,
+			"principal": principal,
+		})
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	// Role assignment exists, keep current state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+}
+
+// Update updates the role assignment (not supported - requires replace)
+func (*RoleAssignment) Update(_ context.Context, _ resource.UpdateRequest, _ *resource.UpdateResponse) {
+	// Role assignments are immutable - updates require replacement
+}
+
+// Delete deletes a role assignment.
+func (r *RoleAssignment) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var model models.RoleAssignment
+	resp.Diagnostics.Append(req.State.Get(ctx, &model)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	roleName := model.RoleName.ValueString()
+	principal := model.Principal.ValueString() // Already normalized when stored
+	clusterAPIURL := model.ClusterAPIURL.ValueString()
+
+	if err := r.createSecurityClient(ctx, clusterAPIURL); err != nil {
+		resp.Diagnostics.AddError("Failed to create SecurityService client", utils.DeserializeGrpcError(err))
+		return
+	}
+	defer r.dataplaneConn.Close()
+
+	// Remove the principal from the role
+	dataplaneReq := &dataplanev1.UpdateRoleMembershipRequest{
+		RoleName: roleName,
+		Remove:   []*dataplanev1.RoleMembership{{Principal: principal}},
+	}
+	consoleReq := &consolev1alpha1.UpdateRoleMembershipRequest{
+		Request: dataplaneReq,
+	}
+
+	_, err := r.SecurityClient.UpdateRoleMembership(ctx, consoleReq)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to unassign role", utils.DeserializeGrpcError(err))
+		return
+	}
+
+	// Remove resource from state
+	resp.State.RemoveResource(ctx)
+}
+
+// ImportState imports the role assignment state
+func (r *RoleAssignment) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	// Expected format: role_name:principal
+	parts := strings.SplitN(req.ID, ":", 2)
+	if len(parts) != 2 {
+		resp.Diagnostics.AddError(
+			"Invalid import ID format",
+			"Expected format: role_name:principal",
+		)
+		return
+	}
+
+	roleName := parts[0]
+	principal := normalizePrincipal(parts[1])
+
+	// Set the imported state (cluster_api_url will be set from the resource configuration)
+	model := models.RoleAssignment{
+		RoleName:  types.StringValue(roleName),
+		Principal: types.StringValue(principal), // Store normalized principal
+		ID:        types.StringValue(fmt.Sprintf("%s:%s", roleName, principal)),
+		// ClusterAPIURL will be set from the resource configuration
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+}
+
+// normalizePrincipal ensures the principal has the correct format for the API
+func normalizePrincipal(principal string) string {
+	// The gRPC API expects just the username, not "User:username"
+	// Remove "User:" prefix if present
+	return strings.TrimPrefix(principal, "User:")
+}
+
+// roleAssignmentExists checks if a role assignment exists
+func (r *RoleAssignment) roleAssignmentExists(ctx context.Context, roleName, principal string) (bool, error) {
+	// Create request to list role members
+	dataplaneReq := &dataplanev1.ListRoleMembersRequest{
+		RoleName: roleName,
+	}
+	consoleReq := &consolev1alpha1.ListRoleMembersRequest{
+		Request: dataplaneReq,
+	}
+
+	// Execute the request
+	resp, err := r.SecurityClient.ListRoleMembers(ctx, consoleReq)
+	if err != nil {
+		// Check for common "not found" errors
+		errStr := strings.ToLower(err.Error())
+		if strings.Contains(errStr, "not found") ||
+			strings.Contains(errStr, "notfound") ||
+			strings.Contains(errStr, "does not exist") ||
+			strings.Contains(errStr, "unknown role") {
+			return false, nil
+		}
+		// For other errors, we should fail rather than assume the assignment doesn't exist
+		return false, fmt.Errorf("failed to list role members for role '%s': %w", roleName, err)
+	}
+
+	// Check if the principal is in the role members
+	if resp.Response != nil && resp.Response.Members != nil {
+		for _, member := range resp.Response.Members {
+			if normalizePrincipal(member.Principal) == principal {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}
+
+// createSecurityClient creates a SecurityService client
+func (r *RoleAssignment) createSecurityClient(ctx context.Context, clusterURL string) error {
+	if r.SecurityClient != nil {
+		return nil // Client already exists
+	}
+
+	if r.dataplaneConn == nil {
+		// Convert cluster API URL to console URL for SecurityService
+		consoleURL := convertToConsoleURL(clusterURL)
+
+		conn, err := cloud.SpawnConn(consoleURL, r.resData.AuthToken, r.resData.ProviderVersion, r.resData.TerraformVersion)
+		if err != nil {
+			return fmt.Errorf("unable to open a connection with the console API at %s: %v", consoleURL, err)
+		}
+		r.dataplaneConn = conn
+	}
+
+	r.SecurityClient = consolev1alpha1grpc.NewSecurityServiceClient(r.dataplaneConn)
+	return nil
+}
+
+// convertToConsoleURL converts a cluster API URL to a console URL
+// e.g., https://api-123456.cluster-id.byoc.prd.cloud.redpanda.com
+//
+//	-> https://console-123456.d110a6bu3l09un9dm4jg.byoc.prd.cloud.redpanda.com
+func convertToConsoleURL(clusterAPIURL string) string {
+	// Simple string replacement to convert api- prefix to console-
+	return strings.Replace(clusterAPIURL, "://api-", "://console-", 1)
+}

--- a/redpanda/resources/roleassignment/resource_role_assignment_test.go
+++ b/redpanda/resources/roleassignment/resource_role_assignment_test.go
@@ -1,0 +1,158 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package roleassignment
+
+import (
+	"testing"
+)
+
+func TestNormalizePrincipal(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "principal without User prefix",
+			input:    "testuser",
+			expected: "testuser",
+		},
+		{
+			name:     "principal with User prefix",
+			input:    "User:testuser",
+			expected: "testuser",
+		},
+		{
+			name:     "principal with email",
+			input:    "user@example.com",
+			expected: "user@example.com",
+		},
+		{
+			name:     "principal with User prefix and email",
+			input:    "User:user@example.com",
+			expected: "user@example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizePrincipal(tt.input)
+			if result != tt.expected {
+				t.Errorf("normalizePrincipal(%q) = %q, expected %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestImportIDFormat(t *testing.T) {
+	tests := []struct {
+		name              string
+		importID          string
+		expectError       bool
+		expectedRole      string
+		expectedPrincipal string
+	}{
+		{
+			name:              "valid import format",
+			importID:          "developer:testuser",
+			expectError:       false,
+			expectedRole:      "developer",
+			expectedPrincipal: "testuser",
+		},
+		{
+			name:              "valid import format with User prefix",
+			importID:          "admin:User:testuser",
+			expectError:       false,
+			expectedRole:      "admin",
+			expectedPrincipal: "testuser",
+		},
+		{
+			name:        "invalid format - missing principal",
+			importID:    "developer",
+			expectError: true,
+		},
+		{
+			name:              "valid format with colon in principal",
+			importID:          "developer:testuser:extra",
+			expectError:       false,
+			expectedRole:      "developer",
+			expectedPrincipal: "testuser:extra",
+		},
+		{
+			name:        "empty import ID",
+			importID:    "",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// This test validates the expected import ID format
+			// The actual ImportState method would be tested in integration tests
+			parts := splitImportID(tt.importID)
+
+			if tt.expectError {
+				if len(parts) == 2 {
+					t.Errorf("Expected error for import ID %q, but parsing succeeded", tt.importID)
+				}
+			} else {
+				if len(parts) != 2 {
+					t.Errorf("Expected valid parsing for import ID %q, but got %d parts", tt.importID, len(parts))
+					return
+				}
+
+				role := parts[0]
+				principal := normalizePrincipal(parts[1])
+
+				if role != tt.expectedRole {
+					t.Errorf("Expected role %q, got %q", tt.expectedRole, role)
+				}
+
+				if principal != tt.expectedPrincipal {
+					t.Errorf("Expected principal %q, got %q", tt.expectedPrincipal, principal)
+				}
+			}
+		})
+	}
+}
+
+// Helper function to simulate import ID parsing - mimics strings.SplitN(importID, ":", 2)
+func splitImportID(importID string) []string {
+	if importID == "" {
+		return []string{}
+	}
+
+	// Find first colon
+	colonIndex := -1
+	for i, r := range importID {
+		if r == ':' {
+			colonIndex = i
+			break
+		}
+	}
+
+	if colonIndex == -1 {
+		return []string{importID}
+	}
+
+	// Split into exactly 2 parts at the first colon
+	parts := []string{
+		importID[:colonIndex],
+		importID[colonIndex+1:],
+	}
+
+	return parts
+}


### PR DESCRIPTION
Implements a new Terraform resource for managing role assignments in Redpanda clusters, enabling users to assign existing roles to principals through the Terraform provider.

Implementation details:
- Follows existing provider conventions from ACL and User resources
- Uses consolev1alpha1grpc.SecurityServiceClient for gRPC communication
- Integrates with existing dataplane connection management
- Includes comprehensive error handling and validation
- Updates require resource replacement (role assignments are immutable)

This enables Infrastructure as Code management of Redpanda RBAC role assignments, complementing the existing ACL resource for fine-grained permission management.

Files added:
- redpanda/models/role_assignment.go
- redpanda/resources/roleassignment/resource_role_assignment.go
- redpanda/resources/roleassignment/resource_role_assignment_test.go
- docs/resources/role_assignment.md
- examples/resources/redpanda_role_assignment/resource.tf

Files modified:
- redpanda/redpanda.go (provider registration)

Fixes #169.