### PR TITLE
DOC-1578 Update TF docs that changing throughput_tier destroys cluster

### DIFF
--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -25,7 +25,7 @@ Data source for a Redpanda Cloud cluster
 - `cluster_api_url` (String) The URL of the cluster API.
 - `cluster_configuration` (Attributes) Configuration for the cluster. (see [below for nested schema](#nestedatt--cluster_configuration))
 - `cluster_type` (String) Cluster type. Type is immutable and can only be set on cluster creation.
-- `connection_type` (String) Cluster connection type. Private clusters are not exposed to the internet. For BYOC clusters, Private is best-practice.
+- `connection_type` (String) Cluster connection type. Private clusters are not exposed to the internet. For BYOC clusters, private is best-practice.
 - `created_at` (String) Timestamp when the cluster was created.
 - `customer_managed_resources` (Attributes) Customer managed resources configuration for the cluster. (see [below for nested schema](#nestedatt--customer_managed_resources))
 - `gcp_global_access_enabled` (Boolean) If true, GCP global access is enabled.
@@ -46,7 +46,7 @@ Data source for a Redpanda Cloud cluster
 - `state` (String) Current state of the cluster.
 - `state_description` (Attributes) Detailed state description when cluster is in a non-ready state. (see [below for nested schema](#nestedatt--state_description))
 - `tags` (Map of String) Tags placed on cloud resources.
-- `throughput_tier` (String) Throughput tier of the cluster.
+- `throughput_tier` (String) Usage tier of the cluster.
 - `zones` (List of String) Zones of the cluster. Must be valid zones within the selected region. If multiple zones are used, the cluster is a multi-AZ cluster.
 
 <a id="nestedatt--aws_private_link"></a>

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -23,7 +23,7 @@ Enables the provisioning and management of Redpanda clusters on AWS and GCP. A c
 - `network_id` (String) Network ID where cluster is placed.
 - `region` (String) Cloud provider region. Region represents the name of the region where the cluster will be provisioned.
 - `resource_group_id` (String) Resource group ID of the cluster.
-- `throughput_tier` (String) Usage tier of the cluster. Changing this value will destroy and recreate the cluster.
+- `throughput_tier` (String) Usage tier of the cluster. WARNING: Do not modify after it is set. When allow_deletion is true, modifying this forces replacement of the cluster - Terraform will destroy the existing cluster and create a new one, causing data loss.
 - `zones` (List of String) Zones of the cluster. Must be valid zones within the selected region. If multiple zones are used, the cluster is a multi-AZ cluster.
 
 ### Optional

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -17,13 +17,13 @@ Enables the provisioning and management of Redpanda clusters on AWS and GCP. A c
 ### Required
 
 - `cloud_provider` (String) Cloud provider where resources are created.
-- `cluster_type` (String) Cluster type. Type is immutable and can only be set on cluster creation. Can be one of dedicated or byoc.
-- `connection_type` (String) Cluster connection type. Private clusters are not exposed to the internet. For BYOC clusters, Private is best-practice.
+- `cluster_type` (String) Cluster type. Type is immutable and can only be set on cluster creation. Can be either byoc or dedicated.
+- `connection_type` (String) Cluster connection type. Private clusters are not exposed to the internet. For BYOC clusters, private is best-practice.
 - `name` (String) Unique name of the cluster.
 - `network_id` (String) Network ID where cluster is placed.
 - `region` (String) Cloud provider region. Region represents the name of the region where the cluster will be provisioned.
 - `resource_group_id` (String) Resource group ID of the cluster.
-- `throughput_tier` (String) Throughput tier of the cluster.
+- `throughput_tier` (String) Usage tier of the cluster. Changing this value will destroy and recreate the cluster.
 - `zones` (List of String) Zones of the cluster. Must be valid zones within the selected region. If multiple zones are used, the cluster is a multi-AZ cluster.
 
 ### Optional

--- a/redpanda/resources/cluster/schema_datasource.go
+++ b/redpanda/resources/cluster/schema_datasource.go
@@ -22,7 +22,7 @@ func datasourceClusterSchema() schema.Schema {
 			},
 			"connection_type": schema.StringAttribute{
 				Computed:    true,
-				Description: "Cluster connection type. Private clusters are not exposed to the internet. For BYOC clusters, Private is best-practice.",
+				Description: "Cluster connection type. Private clusters are not exposed to the internet. For BYOC clusters, private is best-practice.",
 			},
 			"cloud_provider": schema.StringAttribute{
 				Computed:    true,
@@ -34,7 +34,7 @@ func datasourceClusterSchema() schema.Schema {
 			},
 			"throughput_tier": schema.StringAttribute{
 				Computed:    true,
-				Description: "Throughput tier of the cluster.",
+				Description: "Usage tier of the cluster.",
 			},
 			"region": schema.StringAttribute{
 				Computed:    true,

--- a/redpanda/resources/cluster/schema_resource.go
+++ b/redpanda/resources/cluster/schema_resource.go
@@ -56,7 +56,7 @@ func resourceClusterSchema() schema.Schema {
 			},
 			"throughput_tier": schema.StringAttribute{
 				Required:      true,
-				Description:   "Usage tier of the cluster. Changing this value will destroy and recreate the cluster.",
+				Description:   "Usage tier of the cluster. WARNING: Do not modify after it is set. When allow_deletion is true, modifying this forces replacement of the cluster - Terraform will destroy the existing cluster and create a new one, causing data loss.",
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"region": schema.StringAttribute{

--- a/redpanda/resources/cluster/schema_resource.go
+++ b/redpanda/resources/cluster/schema_resource.go
@@ -28,13 +28,13 @@ func resourceClusterSchema() schema.Schema {
 			},
 			"cluster_type": schema.StringAttribute{
 				Required:      true,
-				Description:   "Cluster type. Type is immutable and can only be set on cluster creation. Can be one of dedicated or byoc.",
+				Description:   "Cluster type. Type is immutable and can only be set on cluster creation. Can be either byoc or dedicated.",
 				Validators:    validators.ClusterTypes(),
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"connection_type": schema.StringAttribute{
 				Required:    true,
-				Description: "Cluster connection type. Private clusters are not exposed to the internet. For BYOC clusters, Private is best-practice.",
+				Description: "Cluster connection type. Private clusters are not exposed to the internet. For BYOC clusters, private is best-practice.",
 				Validators: []validator.String{
 					validators.ConnectionTypes(),
 					validators.RequirePrivateConnectionValidator{},
@@ -56,7 +56,7 @@ func resourceClusterSchema() schema.Schema {
 			},
 			"throughput_tier": schema.StringAttribute{
 				Required:      true,
-				Description:   "Throughput tier of the cluster.",
+				Description:   "Usage tier of the cluster. Changing this value will destroy and recreate the cluster.",
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"region": schema.StringAttribute{


### PR DESCRIPTION
This pull request adds a warning that modifying the `throughput_tier` property after creation will destroy and recreate the cluster.

Fixes https://redpandadata.atlassian.net/browse/DOC-1578