### PR TITLE
Generate ACL id field

### DIFF
--- a/redpanda/resources/acl/resource_acl.go
+++ b/redpanda/resources/acl/resource_acl.go
@@ -180,6 +180,16 @@ func (a *ACL) Create(ctx context.Context, request resource.CreateRequest, respon
 		return
 	}
 
+	// Generate a composite ID from the ACL fields
+	aclID := fmt.Sprintf("%s:%s:%s:%s:%s:%s:%s",
+		model.ResourceType.ValueString(),
+		model.ResourceName.ValueString(),
+		model.ResourcePatternType.ValueString(),
+		model.Principal.ValueString(),
+		model.Host.ValueString(),
+		model.Operation.ValueString(),
+		model.PermissionType.ValueString())
+
 	response.Diagnostics.Append(response.State.Set(ctx, &models.ACL{
 		ResourceType:        model.ResourceType,
 		ResourceName:        model.ResourceName,
@@ -189,6 +199,7 @@ func (a *ACL) Create(ctx context.Context, request resource.CreateRequest, respon
 		Operation:           model.Operation,
 		PermissionType:      model.PermissionType,
 		ClusterAPIURL:       model.ClusterAPIURL,
+		ID:                  types.StringValue(aclID),
 	})...)
 }
 
@@ -245,6 +256,16 @@ func (a *ACL) Read(ctx context.Context, request resource.ReadRequest, response *
 
 	for _, res := range aclList.Resources {
 		if res.ResourceName == model.ResourceName.ValueString() && res.ResourceType == resourceType && res.ResourcePatternType == resourcePatternType {
+			// Generate the same composite ID as in Create
+			aclID := fmt.Sprintf("%s:%s:%s:%s:%s:%s:%s",
+				model.ResourceType.ValueString(),
+				model.ResourceName.ValueString(),
+				model.ResourcePatternType.ValueString(),
+				model.Principal.ValueString(),
+				model.Host.ValueString(),
+				model.Operation.ValueString(),
+				model.PermissionType.ValueString())
+
 			response.Diagnostics.Append(response.State.Set(ctx, &models.ACL{
 				ResourceType:        types.StringValue(aclResourceTypeToString(res.ResourceType)),
 				ResourceName:        types.StringValue(res.ResourceName),
@@ -254,6 +275,7 @@ func (a *ACL) Read(ctx context.Context, request resource.ReadRequest, response *
 				Operation:           model.Operation,
 				PermissionType:      model.PermissionType,
 				ClusterAPIURL:       model.ClusterAPIURL,
+				ID:                  types.StringValue(aclID),
 			})...)
 			return
 		}


### PR DESCRIPTION
fixes #275 

The problem was that the id field was defined in the schema but never being set in the Create and Read methods.

Changes:
  1. Create method: Added composite ID generation using all the ACL fields that uniquely identify an ACL
  2. Read method: Added the same composite ID generation to maintain consistency
  3. Related unit tests

The composite ID format is: resource_type:resource_name:resource_pattern_type:principal:host:operation:permission_type

This ensures that:
  - The ID field will always have a valid string value after planning
  - Tools like upjet can properly cast the ID to a string
  - The ID is deterministic and consistent across Create/Read operations
  - The ID uniquely identifies each ACL resource combination

The fix follows the same pattern used in other resources like role assignments (resource_roleassignment.go:127) that also generate composite IDs when the underlying API doesn't provide a single unique identifier.