### PR TITLE
Add all URL outputs for Serverless Clusters

### DIFF
--- a/docs/resources/serverless_cluster.md
+++ b/docs/resources/serverless_cluster.md
@@ -28,7 +28,13 @@ Enables the provisioning and management of Redpanda Serverless clusters. A Serve
 ### Read-Only
 
 - `cluster_api_url` (String, Deprecated) The URL of the dataplane API for the serverless cluster
+- `console_private_url` (String) Private Console URL for the serverless cluster
+- `console_url` (String) Public Console URL for the serverless cluster
+- `dataplane_api` (Attributes) Dataplane API endpoints for the serverless cluster (see [below for nested schema](#nestedatt--dataplane_api))
 - `id` (String) The ID of the serverless cluster
+- `kafka_api` (Attributes) Kafka API endpoints for the serverless cluster (see [below for nested schema](#nestedatt--kafka_api))
+- `prometheus` (Attributes) Prometheus metrics endpoints for the serverless cluster (see [below for nested schema](#nestedatt--prometheus))
+- `schema_registry` (Attributes) Schema Registry endpoints for the serverless cluster (see [below for nested schema](#nestedatt--schema_registry))
 
 <a id="nestedatt--networking_config"></a>
 ### Nested Schema for `networking_config`
@@ -37,6 +43,42 @@ Optional:
 
 - `private` (String) Private network state. Valid values: STATE_UNSPECIFIED, STATE_DISABLED, STATE_ENABLED
 - `public` (String) Public network state. Valid values: STATE_UNSPECIFIED, STATE_DISABLED, STATE_ENABLED
+
+
+<a id="nestedatt--dataplane_api"></a>
+### Nested Schema for `dataplane_api`
+
+Read-Only:
+
+- `private_url` (String) Private Dataplane API URL
+- `url` (String) Public Dataplane API URL
+
+
+<a id="nestedatt--kafka_api"></a>
+### Nested Schema for `kafka_api`
+
+Read-Only:
+
+- `private_seed_brokers` (List of String) Private Kafka API seed brokers (bootstrap servers)
+- `seed_brokers` (List of String) Public Kafka API seed brokers (bootstrap servers)
+
+
+<a id="nestedatt--prometheus"></a>
+### Nested Schema for `prometheus`
+
+Read-Only:
+
+- `private_url` (String) Private Prometheus metrics URL
+- `url` (String) Public Prometheus metrics URL
+
+
+<a id="nestedatt--schema_registry"></a>
+### Nested Schema for `schema_registry`
+
+Read-Only:
+
+- `private_url` (String) Private Schema Registry URL
+- `url` (String) Public Schema Registry URL
 
 ## Example Usage
 

--- a/redpanda/models/serverlesscluster/resource_model_gen.go
+++ b/redpanda/models/serverlesscluster/resource_model_gen.go
@@ -24,11 +24,17 @@ import (
 
 // ResourceModel represents the Terraform schema for the serverlesscluster resource.
 type ResourceModel struct {
-	ClusterAPIURL    types.String `tfsdk:"cluster_api_url"`
-	ID               types.String `tfsdk:"id"`
-	Name             types.String `tfsdk:"name"`
-	NetworkingConfig types.Object `tfsdk:"networking_config"`
-	PrivateLinkID    types.String `tfsdk:"private_link_id"`
-	ResourceGroupID  types.String `tfsdk:"resource_group_id"`
-	ServerlessRegion types.String `tfsdk:"serverless_region"`
+	ClusterAPIURL     types.String `tfsdk:"cluster_api_url"`
+	ConsolePrivateURL types.String `tfsdk:"console_private_url"`
+	ConsoleURL        types.String `tfsdk:"console_url"`
+	DataplaneAPI      types.Object `tfsdk:"dataplane_api"`
+	ID                types.String `tfsdk:"id"`
+	KafkaAPI          types.Object `tfsdk:"kafka_api"`
+	Name              types.String `tfsdk:"name"`
+	NetworkingConfig  types.Object `tfsdk:"networking_config"`
+	PrivateLinkID     types.String `tfsdk:"private_link_id"`
+	Prometheus        types.Object `tfsdk:"prometheus"`
+	ResourceGroupID   types.String `tfsdk:"resource_group_id"`
+	SchemaRegistry    types.Object `tfsdk:"schema_registry"`
+	ServerlessRegion  types.String `tfsdk:"serverless_region"`
 }

--- a/redpanda/resources/serverlesscluster/resource_serverless_cluster.go
+++ b/redpanda/resources/serverlesscluster/resource_serverless_cluster.go
@@ -26,6 +26,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -124,9 +126,89 @@ func ResourceServerlessClusterSchema() schema.Schema {
 			},
 			"cluster_api_url": schema.StringAttribute{
 				Computed:           true,
-				DeprecationMessage: "This field is deprecated and will be removed in a future version. Use the dataplane API URL from the cluster details instead.",
+				DeprecationMessage: "This field is deprecated and will be removed in a future version. Use dataplane_api.url instead.",
 				Description:        "The URL of the dataplane API for the serverless cluster",
 				PlanModifiers:      []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"kafka_api": schema.SingleNestedAttribute{
+				Computed:      true,
+				Description:   "Kafka API endpoints for the serverless cluster",
+				PlanModifiers: []planmodifier.Object{objectplanmodifier.UseStateForUnknown()},
+				Attributes: map[string]schema.Attribute{
+					"seed_brokers": schema.ListAttribute{
+						Computed:      true,
+						ElementType:   types.StringType,
+						Description:   "Public Kafka API seed brokers (bootstrap servers)",
+						PlanModifiers: []planmodifier.List{listplanmodifier.UseStateForUnknown()},
+					},
+					"private_seed_brokers": schema.ListAttribute{
+						Computed:      true,
+						ElementType:   types.StringType,
+						Description:   "Private Kafka API seed brokers (bootstrap servers)",
+						PlanModifiers: []planmodifier.List{listplanmodifier.UseStateForUnknown()},
+					},
+				},
+			},
+			"schema_registry": schema.SingleNestedAttribute{
+				Computed:      true,
+				Description:   "Schema Registry endpoints for the serverless cluster",
+				PlanModifiers: []planmodifier.Object{objectplanmodifier.UseStateForUnknown()},
+				Attributes: map[string]schema.Attribute{
+					"url": schema.StringAttribute{
+						Computed:      true,
+						Description:   "Public Schema Registry URL",
+						PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+					},
+					"private_url": schema.StringAttribute{
+						Computed:      true,
+						Description:   "Private Schema Registry URL",
+						PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+					},
+				},
+			},
+			"dataplane_api": schema.SingleNestedAttribute{
+				Computed:      true,
+				Description:   "Dataplane API endpoints for the serverless cluster",
+				PlanModifiers: []planmodifier.Object{objectplanmodifier.UseStateForUnknown()},
+				Attributes: map[string]schema.Attribute{
+					"url": schema.StringAttribute{
+						Computed:      true,
+						Description:   "Public Dataplane API URL",
+						PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+					},
+					"private_url": schema.StringAttribute{
+						Computed:      true,
+						Description:   "Private Dataplane API URL",
+						PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+					},
+				},
+			},
+			"console_url": schema.StringAttribute{
+				Computed:      true,
+				Description:   "Public Console URL for the serverless cluster",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"console_private_url": schema.StringAttribute{
+				Computed:      true,
+				Description:   "Private Console URL for the serverless cluster",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"prometheus": schema.SingleNestedAttribute{
+				Computed:      true,
+				Description:   "Prometheus metrics endpoints for the serverless cluster",
+				PlanModifiers: []planmodifier.Object{objectplanmodifier.UseStateForUnknown()},
+				Attributes: map[string]schema.Attribute{
+					"url": schema.StringAttribute{
+						Computed:      true,
+						Description:   "Public Prometheus metrics URL",
+						PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+					},
+					"private_url": schema.StringAttribute{
+						Computed:      true,
+						Description:   "Private Prometheus metrics URL",
+						PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+					},
+				},
 			},
 		},
 	}

--- a/redpanda/resources/serverlesscluster/serverless_cluster.go
+++ b/redpanda/resources/serverlesscluster/serverless_cluster.go
@@ -15,6 +15,8 @@ func generateModel(cluster *controlplanev1.ServerlessCluster) *serverlesscluster
 		ResourceGroupID:  types.StringValue(cluster.ResourceGroupId),
 		ID:               types.StringValue(cluster.Id),
 	}
+
+	// Deprecated cluster_api_url (kept for backward compatibility)
 	if cluster.DataplaneApi != nil {
 		output.ClusterAPIURL = types.StringValue(cluster.DataplaneApi.Url)
 	}
@@ -43,6 +45,99 @@ func generateModel(cluster *controlplanev1.ServerlessCluster) *serverlesscluster
 		output.NetworkingConfig = types.ObjectNull(map[string]attr.Type{
 			"private": types.StringType,
 			"public":  types.StringType,
+		})
+	}
+
+	// Set kafka_api
+	if cluster.KafkaApi != nil {
+		seedBrokers := make([]attr.Value, len(cluster.KafkaApi.SeedBrokers))
+		for i, broker := range cluster.KafkaApi.SeedBrokers {
+			seedBrokers[i] = types.StringValue(broker)
+		}
+		privateSeedBrokers := make([]attr.Value, len(cluster.KafkaApi.PrivateSeedBrokers))
+		for i, broker := range cluster.KafkaApi.PrivateSeedBrokers {
+			privateSeedBrokers[i] = types.StringValue(broker)
+		}
+
+		kafkaAPIObj, _ := types.ObjectValue(
+			map[string]attr.Type{
+				"seed_brokers":         types.ListType{ElemType: types.StringType},
+				"private_seed_brokers": types.ListType{ElemType: types.StringType},
+			},
+			map[string]attr.Value{
+				"seed_brokers":         types.ListValueMust(types.StringType, seedBrokers),
+				"private_seed_brokers": types.ListValueMust(types.StringType, privateSeedBrokers),
+			},
+		)
+		output.KafkaAPI = kafkaAPIObj
+	} else {
+		output.KafkaAPI = types.ObjectNull(map[string]attr.Type{
+			"seed_brokers":         types.ListType{ElemType: types.StringType},
+			"private_seed_brokers": types.ListType{ElemType: types.StringType},
+		})
+	}
+
+	// Set schema_registry
+	if cluster.SchemaRegistry != nil {
+		schemaRegistryObj, _ := types.ObjectValue(
+			map[string]attr.Type{
+				"url":         types.StringType,
+				"private_url": types.StringType,
+			},
+			map[string]attr.Value{
+				"url":         types.StringValue(cluster.SchemaRegistry.Url),
+				"private_url": types.StringValue(cluster.SchemaRegistry.PrivateUrl),
+			},
+		)
+		output.SchemaRegistry = schemaRegistryObj
+	} else {
+		output.SchemaRegistry = types.ObjectNull(map[string]attr.Type{
+			"url":         types.StringType,
+			"private_url": types.StringType,
+		})
+	}
+
+	// Set dataplane_api
+	if cluster.DataplaneApi != nil {
+		dataplaneAPIObj, _ := types.ObjectValue(
+			map[string]attr.Type{
+				"url":         types.StringType,
+				"private_url": types.StringType,
+			},
+			map[string]attr.Value{
+				"url":         types.StringValue(cluster.DataplaneApi.Url),
+				"private_url": types.StringValue(cluster.DataplaneApi.PrivateUrl),
+			},
+		)
+		output.DataplaneAPI = dataplaneAPIObj
+	} else {
+		output.DataplaneAPI = types.ObjectNull(map[string]attr.Type{
+			"url":         types.StringType,
+			"private_url": types.StringType,
+		})
+	}
+
+	// Set console URLs
+	output.ConsoleURL = types.StringValue(cluster.ConsoleUrl)
+	output.ConsolePrivateURL = types.StringValue(cluster.ConsolePrivateUrl)
+
+	// Set prometheus
+	if cluster.Prometheus != nil {
+		prometheusObj, _ := types.ObjectValue(
+			map[string]attr.Type{
+				"url":         types.StringType,
+				"private_url": types.StringType,
+			},
+			map[string]attr.Value{
+				"url":         types.StringValue(cluster.Prometheus.Url),
+				"private_url": types.StringValue(cluster.Prometheus.PrivateUrl),
+			},
+		)
+		output.Prometheus = prometheusObj
+	} else {
+		output.Prometheus = types.ObjectNull(map[string]attr.Type{
+			"url":         types.StringType,
+			"private_url": types.StringType,
 		})
 	}
 


### PR DESCRIPTION
These include both public and private as well as kafka, schema registry console and prometheus.