### PR TITLE
Cluster rpsql

### DIFF
--- a/cmd/schemagen/main.go
+++ b/cmd/schemagen/main.go
@@ -342,6 +342,10 @@ func run(cloudv2Root, protoPkg, messageName, configPath, funcName, schemaType, o
 			return fmt.Errorf("derive model import path: %w", err)
 		}
 		modelAlias := pkgName + "model"
+		innerGetter, err := schemagen.ProtoValidatorInnerGetter(cfg, protoLookup)
+		if err != nil {
+			return fmt.Errorf("resolve proto validator inner getter: %w", err)
+		}
 		validatorPath := filepath.Join(filepath.Dir(output), "proto_validator_gen.go")
 		valSrc, err := schemagen.GenerateProtoValidator(schemagen.ProtoValidatorData{
 			License:         schemagen.LicenseHeader(),
@@ -352,6 +356,7 @@ func run(cloudv2Root, protoPkg, messageName, configPath, funcName, schemaType, o
 			ModelType:       schemagen.ModelTypeResource,
 			ExpandFunc:      "ExpandCreate",
 			ResourceLabel:   pkgName,
+			InnerGetter:     innerGetter,
 			PreValidateHook: cfg.API.PreValidateHook,
 			PostExpandHook:  cfg.API.PostExpandHook,
 			SkippedFields:   schemagen.CollectSkippedValidationFields(cfg),

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -44,6 +44,7 @@ Enables the provisioning and management of Redpanda clusters on AWS and GCP. A c
 - `read_replica_cluster_ids` (List of String) IDs of clusters that can create read-only topics from this cluster
 - `redpanda_node_count` (Number) Number of Redpanda broker nodes
 - `redpanda_version` (String) Redpanda Version
+- `rpsql` (Attributes) Rpsql configuration (see [below for nested schema](#nestedatt--rpsql))
 - `schema_registry` (Attributes) Cluster's Schema Registry properties. (see [below for nested schema](#nestedatt--schema_registry))
 - `tags` (Map of String) Tags placed on cloud resources. Server-managed keys (prefixed with `redpanda-`) are filtered out of state.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
@@ -613,6 +614,19 @@ Optional:
 - `day_of_week` (String) Represents a day of the week. - MONDAY: Monday - TUESDAY: Tuesday - WEDNESDAY: Wednesday - THURSDAY: Thursday - FRIDAY: Friday - SATURDAY: Saturday - SUNDAY: Sunday
 - `hour_of_day` (Number) always UTC. Must be between 0 and 23 (inclusive).
 
+
+
+<a id="nestedatt--rpsql"></a>
+### Nested Schema for `rpsql`
+
+Optional:
+
+- `enabled` (Boolean) Whether Rpsql is enabled
+- `replicas` (Number) Replicas
+
+Read-Only:
+
+- `url` (String) Rpsql URL
 
 
 <a id="nestedatt--schema_registry"></a>

--- a/internal/schemagen/auto_plan_modifiers_test.go
+++ b/internal/schemagen/auto_plan_modifiers_test.go
@@ -98,3 +98,36 @@ func TestMerge_PlanModifiers_SkippedWhenDefaultSet(t *testing.T) {
 		t.Errorf("expected no PlanModifiers when Default is set; got %q", got)
 	}
 }
+
+// The None sentinel suppresses the auto-added state modifier and emits nothing,
+// for a computed leaf that would otherwise get UseStateForUnknown.
+func TestMerge_PlanModifiers_NoneSuppresses(t *testing.T) {
+	proto := &ProtoMessage{Name: "Thing", Fields: []ProtoField{}}
+	tru := true
+	cfg := &Config{
+		Fields: map[string]FieldConfig{
+			"endpoint": {
+				Extra:         true,
+				Type:          "string",
+				Computed:      &tru,
+				PlanModifiers: []string{modNone},
+			},
+		},
+	}
+	attrs, _, _, errs := Merge(proto, cfg, "resource", nil)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	var found bool
+	for _, a := range attrs {
+		if a.Name == "endpoint" {
+			found = true
+			if a.PlanModifiers != "" {
+				t.Errorf("expected no PlanModifiers with [None]; got %q", a.PlanModifiers)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("endpoint attr not found")
+	}
+}

--- a/internal/schemagen/classifier.go
+++ b/internal/schemagen/classifier.go
@@ -37,6 +37,11 @@ func frameForAttr(attr *SchemaAttr) ancestorFrame {
 const (
 	modUseStateForUnknown        = "UseStateForUnknown"
 	modUseNonNullStateForUnknown = "UseNonNullStateForUnknown"
+	// modNone is a sentinel meaning "emit no plan modifier" — it suppresses the
+	// auto-added state modifier. For a computed leaf whose value changes with a
+	// sibling (e.g. a URL empty until `enabled` flips true), a state-pin modifier
+	// would pin the stale value and trip inconsistent-result.
+	modNone = "None"
 )
 
 func chooseStateModifier(ancestors []ancestorFrame, leafIsUserInput bool) string {

--- a/internal/schemagen/derive_validators_test.go
+++ b/internal/schemagen/derive_validators_test.go
@@ -248,8 +248,7 @@ func TestConstraintSummary_Int32Range(t *testing.T) {
 	}
 }
 
-// TestConstraintSummary_MixedBounds exercises gte+lt and gt+lte combinations,
-// which previously fell through to the bare-min case.
+// TestConstraintSummary_MixedBounds exercises gte+lt and gt+lte combinations.
 func TestConstraintSummary_MixedBounds(t *testing.T) {
 	cases := []struct {
 		name  string

--- a/internal/schemagen/merger.go
+++ b/internal/schemagen/merger.go
@@ -712,7 +712,7 @@ func applyAutoPlanModifiers(attrs []SchemaAttr, ancestors []ancestorFrame, mc *m
 
 func containsStateNullModifier(names []string) bool {
 	for _, n := range names {
-		if n == modUseStateForUnknown || n == modUseNonNullStateForUnknown {
+		if n == modUseStateForUnknown || n == modUseNonNullStateForUnknown || n == modNone {
 			return true
 		}
 		if def, ok := planModifierRegistry[n]; ok && def.subsumesStateNullAxis {
@@ -732,11 +732,19 @@ func planModifierExpr(attrType string, modifiers []string) (string, error) {
 	}
 	inners := make([]string, 0, len(modifiers))
 	for _, m := range modifiers {
+		if m == modNone {
+			// Sentinel: suppresses the auto-added state modifier and emits
+			// nothing on its own.
+			continue
+		}
 		if def, ok := planModifierRegistry[m]; ok {
 			inners = append(inners, def.expr(pkg))
 			continue
 		}
 		inners = append(inners, fmt.Sprintf("%splanmodifier.%s()", pkg, m))
+	}
+	if len(inners) == 0 {
+		return "", nil
 	}
 	return fmt.Sprintf("[]planmodifier.%s{%s}",
 		strings.ToUpper(pkg[:1])+pkg[1:], strings.Join(inners, ", ")), nil

--- a/internal/schemagen/proto_validator_gen.go
+++ b/internal/schemagen/proto_validator_gen.go
@@ -34,6 +34,11 @@ type ProtoValidatorData struct {
 	ExpandFunc    string
 	ResourceLabel string
 
+	// InnerGetter unwraps the Create request to the inner spec message to
+	// validate (e.g. "GetCluster"), keeping violation paths schema-relative so
+	// they match the skip-set. Empty for flat requests (validated directly).
+	InnerGetter string
+
 	PreValidateHook string
 
 	PostExpandHook string
@@ -115,7 +120,7 @@ func (protoValidator) ValidateResource(ctx context.Context, req resource.Validat
 		return
 	}
 {{- end }}
-	resp.Diagnostics.Append(rpvalidate.Validate(path.Empty(), payload{{if .SkippedFields}},
+	resp.Diagnostics.Append(rpvalidate.Validate(path.Empty(), payload{{if .InnerGetter}}.{{.InnerGetter}}(){{end}}{{if .SkippedFields}},
 {{- range $i, $f := .SkippedFields}}
 		{{printf "%q" $f}},
 {{- end}}
@@ -141,6 +146,25 @@ func CollectSkippedValidationFields(cfg *Config) []string {
 	collectSkipped("", cfg.Fields, &out)
 	sort.Strings(out)
 	return out
+}
+
+// ProtoValidatorInnerGetter resolves the getter that unwraps a Create request
+// to its inner spec message (e.g. "GetCluster"), or "" for a flat request whose
+// type is itself the payload. The inner message yields schema-relative
+// violation paths that match the skip-set; the wrapper would prefix them and
+// break the exact-match skip lookup. Non-mutating.
+func ProtoValidatorInnerGetter(cfg *Config, lookup ProtoLookup) (string, error) {
+	if cfg == nil || cfg.API == nil || cfg.API.Create == nil {
+		return "", nil
+	}
+	rpc := *cfg.API.Create
+	if err := inferRPCPayload(&rpc, lookup); err != nil {
+		return "", err
+	}
+	if rpc.PayloadField == "" {
+		return "", nil
+	}
+	return "Get" + toProtoGoName(rpc.PayloadField), nil
 }
 
 func collectSkipped(prefix string, fields map[string]FieldConfig, out *[]string) {

--- a/internal/schemagen/proto_validator_gen_test.go
+++ b/internal/schemagen/proto_validator_gen_test.go
@@ -49,3 +49,48 @@ func TestGenerateProtoValidator(t *testing.T) {
 		}
 	}
 }
+
+// A non-empty InnerGetter validates the unwrapped Create payload so violation
+// paths stay schema-relative and match the skip-set.
+func TestGenerateProtoValidator_InnerGetter(t *testing.T) {
+	src, err := GenerateProtoValidator(ProtoValidatorData{
+		Package:       "cluster",
+		ResourceType:  "Cluster",
+		ModelImport:   "github.com/redpanda-data/terraform-provider-redpanda/redpanda/models/cluster",
+		ModelAlias:    "clustermodel",
+		ModelType:     ModelTypeResource,
+		ExpandFunc:    "ExpandCreate",
+		ResourceLabel: "cluster",
+		InnerGetter:   "GetCluster",
+		SkippedFields: []string{"rpsql"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "rpvalidate.Validate(path.Empty(), payload.GetCluster(),"; !strings.Contains(string(src), want) {
+		t.Errorf("generated source missing %q\n--- got ---\n%s", want, src)
+	}
+}
+
+func TestProtoValidatorInnerGetter(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cfg  *Config
+		want string
+	}{
+		{"wrapped", &Config{API: &APIConfig{Create: &RPCConfig{PayloadField: "cluster"}}}, "GetCluster"},
+		{"snake wrapper", &Config{API: &APIConfig{Create: &RPCConfig{PayloadField: "resource_group"}}}, "GetResourceGroup"},
+		{"flat", &Config{API: &APIConfig{Create: &RPCConfig{}}}, ""},
+		{"no create rpc", &Config{}, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ProtoValidatorInnerGetter(tc.cfg, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/testutil/mock/fakes/cluster.go
+++ b/internal/testutil/mock/fakes/cluster.go
@@ -194,6 +194,9 @@ func (f *ClusterFake) CreateCluster(_ context.Context, req *controlplanev1.Creat
 			ConsumerAcceptList:  append([]*controlplanev1.GCPPrivateServiceConnectConsumer(nil), spec.GetConsumerAcceptList()...),
 		})
 	}
+	if in.HasRpsql() {
+		cl.SetRpsql(rpsqlStatus(in.GetRpsql()))
+	}
 
 	if f.CreateMutator != nil {
 		f.CreateMutator(cl)
@@ -278,6 +281,12 @@ func (f *ClusterFake) UpdateCluster(_ context.Context, req *controlplanev1.Updat
 					SupportedRegions:  supported,
 				})
 			}
+		case "rpsql.enabled", "rpsql.replicas":
+			// The provider expands the top-level "rpsql" mask into these granular
+			// paths; the diff payload still carries the full rpsql message.
+			if upd.HasRpsql() {
+				cl.SetRpsql(rpsqlStatus(upd.GetRpsql()))
+			}
 		case "gcp_private_service_connect":
 			if upd.HasGcpPrivateServiceConnect() {
 				spec := upd.GetGcpPrivateServiceConnect()
@@ -314,6 +323,23 @@ func (f *ClusterFake) UpdateCluster(_ context.Context, req *controlplanev1.Updat
 	cl.UpdatedAt = timestamppb.Now()
 
 	return &controlplanev1.UpdateClusterOperation{Operation: completedOp(f.op, upd.GetId())}, nil
+}
+
+// rpsqlStatus mirrors the write-shape RPSql onto the read-shape record,
+// assigning a mock endpoint URL when enabled (the real control plane
+// populates url on provisioning; it stays empty while disabled).
+func rpsqlStatus(spec *controlplanev1.RPSql) *controlplanev1.RPSql {
+	if spec == nil {
+		return nil
+	}
+	out := &controlplanev1.RPSql{
+		Enabled:  spec.GetEnabled(),
+		Replicas: spec.GetReplicas(),
+	}
+	if out.Enabled {
+		out.Url = "https://mock.rpsql.redpanda.cloud"
+	}
+	return out
 }
 
 // specToClusterKafkaAPI converts a write-shape KafkaAPISpec to the read-shape

--- a/redpanda/models/cluster/conv_gen.go
+++ b/redpanda/models/cluster/conv_gen.go
@@ -58,6 +58,7 @@ type ClusterResponse interface {
 	GetRedpandaNodeCount() int32
 	GetRegion() string
 	GetResourceGroupId() string
+	GetRpsql() *controlplanev1.RPSql
 	GetSchemaRegistry() *controlplanev1.Cluster_SchemaRegistryStatus
 	GetState() controlplanev1.Cluster_State
 	GetStateDescription() *status.Status
@@ -125,6 +126,7 @@ func Flatten(ctx context.Context, proto ClusterResponse, prev *ResourceModel) (*
 	m.KafkaConnect = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetKafkaConnect(), func() *KafkaConnectModel { v, _ := prev.AsKafkaConnect(ctx); return v }(), KafkaConnectAttrTypes(), FlattenKafkaConnect, &diags)
 	m.MaintenanceWindowConfig = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetMaintenanceWindowConfig(), func() *MaintenanceWindowConfigModel { v, _ := prev.AsMaintenanceWindowConfig(ctx); return v }(), MaintenanceWindowConfigAttrTypes(), FlattenMaintenanceWindowConfig, &diags)
 	m.RedpandaNodeCount = types.Int32Value(proto.GetRedpandaNodeCount())
+	m.Rpsql = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetRpsql(), func() *RpsqlModel { v, _ := prev.AsRpsql(ctx); return v }(), RpsqlAttrTypes(), FlattenRpsql, &diags)
 	m.SchemaRegistry = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetSchemaRegistry(), func() *SchemaRegistryModel { v, _ := prev.AsSchemaRegistry(ctx); return v }(), SchemaRegistryAttrTypes(), FlattenSchemaRegistry, &diags)
 	m.Tags = tagsFromProto(proto)
 	m.ClusterAPIURL = clusterAPIURLFromProto(proto)
@@ -205,6 +207,7 @@ func ExpandCreate(ctx context.Context, m *ResourceModel) (*controlplanev1.Create
 		KafkaConnect:             modelconv.ObjectToMessageWithDiags(ctx, m.KafkaConnect, ExpandKafkaConnect, &diags),
 		MaintenanceWindowConfig:  modelconv.ObjectToMessageWithDiags(ctx, m.MaintenanceWindowConfig, ExpandMaintenanceWindowConfig, &diags),
 		RedpandaNodeCount:        m.RedpandaNodeCount.ValueInt32(),
+		Rpsql:                    modelconv.ObjectToMessageWithDiags(ctx, m.Rpsql, ExpandRpsql, &diags),
 		SchemaRegistry:           modelconv.ObjectToMessageWithDiags(ctx, m.SchemaRegistry, ExpandCreateSchemaRegistry, &diags),
 		CloudProviderTags:        m.TagsForProto(),
 	}
@@ -234,6 +237,7 @@ func ExpandUpdate(ctx context.Context, m *ResourceModel) (*controlplanev1.Cluste
 		KafkaConnect:             modelconv.ObjectToMessageWithDiags(ctx, m.KafkaConnect, ExpandKafkaConnect, &diags),
 		MaintenanceWindowConfig:  modelconv.ObjectToMessageWithDiags(ctx, m.MaintenanceWindowConfig, ExpandMaintenanceWindowConfig, &diags),
 		RedpandaNodeCount:        m.RedpandaNodeCount.ValueInt32(),
+		Rpsql:                    modelconv.ObjectToMessageWithDiags(ctx, m.Rpsql, ExpandRpsql, &diags),
 		SchemaRegistry:           modelconv.ObjectToMessageWithDiags(ctx, m.SchemaRegistry, ExpandUpdateSchemaRegistry, &diags),
 		CloudProviderTags:        m.TagsForProto(),
 		Id:                       m.ID.ValueString(),
@@ -1897,6 +1901,35 @@ func ExpandMaintenanceWindowConfigDayHour(_ context.Context, m *MaintenanceWindo
 	out := &controlplanev1.MaintenanceWindowConfig_DayHour{
 		DayOfWeek: enums.StringToDayOfWeek(m.DayOfWeek.ValueString()),
 		HourOfDay: m.HourOfDay.ValueInt32(),
+	}
+	return out, diags
+}
+
+// FlattenRpsql converts a single proto controlplanev1.RPSql into the
+// corresponding nested model. The prev *RpsqlModel arg carries forward
+// TF-only / sensitive / write-only fields and resolves the proto3
+// null-vs-empty ambiguity for Optional-only scalar leaves (Required leaves
+// flatten directly); pass nil when no prior nested state is available.
+func FlattenRpsql(_ context.Context, proto *controlplanev1.RPSql, prev *RpsqlModel) (RpsqlModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	_ = prev
+	m := RpsqlModel{}
+	m.Enabled = types.BoolValue(proto.GetEnabled())
+	m.Replicas = types.Int32Value(proto.GetReplicas())
+	m.URL = types.StringValue(proto.GetUrl())
+	return m, diags
+}
+
+// ExpandRpsql renders a nested model back into the proto type.
+func ExpandRpsql(_ context.Context, m *RpsqlModel) (*controlplanev1.RPSql, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if m == nil {
+		return nil, diags
+	}
+	out := &controlplanev1.RPSql{
+		Enabled:  m.Enabled.ValueBool(),
+		Replicas: m.Replicas.ValueInt32(),
+		Url:      m.URL.ValueString(),
 	}
 	return out, diags
 }

--- a/redpanda/models/cluster/resource_model_gen.go
+++ b/redpanda/models/cluster/resource_model_gen.go
@@ -60,6 +60,7 @@ type ResourceModel struct {
 	RedpandaVersion                  types.String   `tfsdk:"redpanda_version"`
 	Region                           types.String   `tfsdk:"region"`
 	ResourceGroupID                  types.String   `tfsdk:"resource_group_id"`
+	Rpsql                            types.Object   `tfsdk:"rpsql"`
 	SchemaRegistry                   types.Object   `tfsdk:"schema_registry"`
 	State                            types.String   `tfsdk:"state"`
 	StateDescription                 types.Object   `tfsdk:"state_description"`
@@ -545,6 +546,15 @@ type MaintenanceWindowConfigModel struct {
 type MaintenanceWindowConfigDayHourModel struct {
 	DayOfWeek types.String `tfsdk:"day_of_week"`
 	HourOfDay types.Int32  `tfsdk:"hour_of_day"`
+}
+
+// RpsqlModel mirrors the nested "rpsql" attribute. Use the As/To
+// converters on the parent struct to move between types.Object and this
+// typed form.
+type RpsqlModel struct {
+	Enabled  types.Bool   `tfsdk:"enabled"`
+	Replicas types.Int32  `tfsdk:"replicas"`
+	URL      types.String `tfsdk:"url"`
 }
 
 // SchemaRegistryModel mirrors the nested "schema_registry" attribute. Use the As/To
@@ -1129,6 +1139,16 @@ func MaintenanceWindowConfigDayHourAttrTypes() map[string]attr.Type {
 	}
 }
 
+// RpsqlAttrTypes returns the attr.Type map for the "rpsql" nested
+// attribute.
+func RpsqlAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"enabled":  types.BoolType,
+		"replicas": types.Int32Type,
+		"url":      types.StringType,
+	}
+}
+
 // SchemaRegistryAttrTypes returns the attr.Type map for the "schema_registry" nested
 // attribute.
 func SchemaRegistryAttrTypes() map[string]attr.Type {
@@ -1415,6 +1435,29 @@ func MaintenanceWindowConfigToObject(ctx context.Context, v *MaintenanceWindowCo
 		return types.ObjectNull(MaintenanceWindowConfigAttrTypes()), nil
 	}
 	return types.ObjectValueFrom(ctx, MaintenanceWindowConfigAttrTypes(), v)
+}
+
+// AsRpsql converts the root rpsql attribute from
+// types.Object into its typed form. Returns (nil, nil) when the object is
+// null or unknown. Use this when you want typed field access without
+// manually unpacking .Attributes().
+func (m *ResourceModel) AsRpsql(ctx context.Context) (*RpsqlModel, diag.Diagnostics) {
+	if m == nil || m.Rpsql.IsNull() || m.Rpsql.IsUnknown() {
+		return nil, nil
+	}
+	var out RpsqlModel
+	d := m.Rpsql.As(ctx, &out, basetypes.ObjectAsOptions{})
+	return &out, d
+}
+
+// RpsqlToObject encodes a typed struct back into the
+// types.Object shape expected by the framework. A nil receiver returns
+// types.ObjectNull with the correct attribute types.
+func RpsqlToObject(ctx context.Context, v *RpsqlModel) (types.Object, diag.Diagnostics) {
+	if v == nil {
+		return types.ObjectNull(RpsqlAttrTypes()), nil
+	}
+	return types.ObjectValueFrom(ctx, RpsqlAttrTypes(), v)
 }
 
 // AsSchemaRegistry converts the root schema_registry attribute from
@@ -2368,6 +2411,7 @@ func GenerateMinimalResourceModel(id types.String, timeout timeouts.Value) *Reso
 		RedpandaVersion:                  types.StringNull(),
 		Region:                           types.StringNull(),
 		ResourceGroupID:                  types.StringNull(),
+		Rpsql:                            types.ObjectNull(RpsqlAttrTypes()),
 		SchemaRegistry:                   types.ObjectNull(SchemaRegistryAttrTypes()),
 		State:                            types.StringNull(),
 		StateDescription:                 types.ObjectNull(StateDescriptionAttrTypes()),

--- a/redpanda/resources/cluster/integration_cluster_test.go
+++ b/redpanda/resources/cluster/integration_cluster_test.go
@@ -319,7 +319,11 @@ resource "redpanda_cluster" "test" {
 // subnetName allows the C10 scenario to mutate cmr.gcp.subnet.name.
 // psc_nat_subnet_name is always set to a non-empty value because conv_gen.go
 // flattens the unset proto3 string as "" rather than null.
-func gcpBYOVPCConfig(name, subnetName string) string {
+func gcpBYOVPCConfig(name, subnetName, pscNatSubnet string) string {
+	pscLine := ""
+	if pscNatSubnet != "" {
+		pscLine = fmt.Sprintf("\n      psc_nat_subnet_name   = %q", pscNatSubnet)
+	}
 	return fmt.Sprintf(`
 provider "redpanda" {}
 
@@ -366,12 +370,11 @@ resource "redpanda_cluster" "test" {
         secondary_ipv4_range_pods     = { name = "pods-range" }
         secondary_ipv4_range_services = { name = "svc-range" }
       }
-      tiered_storage_bucket = { name = "tfrp-tiered-bucket" }
-      psc_nat_subnet_name   = "psc-nat-subnet-test"
+      tiered_storage_bucket = { name = "tfrp-tiered-bucket" }%s
     }
   }
 }
-`, name, subnetName)
+`, name, subnetName, pscLine)
 }
 
 // twoRGConfig declares two resource_groups; rgLabel selects which one the
@@ -731,7 +734,7 @@ func TestIntegration_Cluster_CreateAndRefresh_GCP_BYOVPC(t *testing.T) {
 		name       = "tfrp-mock-cl-a5"
 		subnetName = "tfrp-subnet-a"
 	)
-	cfg := gcpBYOVPCConfig(name, subnetName)
+	cfg := gcpBYOVPCConfig(name, subnetName, "psc-nat-subnet-test")
 
 	idPreserved := statecheck.CompareValue(compare.ValuesSame())
 
@@ -1050,6 +1053,56 @@ func TestIntegration_Cluster_UpdateLeaf_KafkaConnect_Enabled(t *testing.T) {
 					statecheck.ExpectKnownValue(clusterAddr,
 						tfjsonpath.New("kafka_connect").AtMapKey("enabled"),
 						knownvalue.Bool(false)),
+					idPreserved.AddStateValue(clusterAddr, tfjsonpath.New("id")),
+				}),
+		},
+	})
+}
+
+// TestIntegration_Cluster_UpdateLeaf_Rpsql exercises the rpsql block in place:
+// enable (null→enabled), enable-after-disable (re-derives the computed url),
+// and a replicas scale — all as ResourceActionUpdate. The scale also proves
+// expandRpsqlPath round-trips the granular mask paths.
+func TestIntegration_Cluster_UpdateLeaf_Rpsql(t *testing.T) {
+	_, factories := clusterSetup(t)
+
+	const name = "tfrp-mock-cl-rpsql"
+	const mockURL = "https://mock.rpsql.redpanda.cloud"
+
+	idPreserved := statecheck.CompareValue(compare.ValuesSame())
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: factories,
+		Steps: []resource.TestStep{
+			integration.CreateStep(clusterAddr,
+				awsDedicatedConfig(name),
+				[]statecheck.StateCheck{
+					statecheck.ExpectKnownValue(clusterAddr, tfjsonpath.New("rpsql"), knownvalue.Null()),
+					idPreserved.AddStateValue(clusterAddr, tfjsonpath.New("id")),
+				}),
+			// Add a disabled block: replicas defaults to 1, url stays empty.
+			integration.UpdateLeafStep(clusterAddr,
+				awsDedicatedConfig(name, `rpsql = { enabled = false }`),
+				[]statecheck.StateCheck{
+					statecheck.ExpectKnownValue(clusterAddr, tfjsonpath.New("rpsql").AtMapKey("enabled"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(clusterAddr, tfjsonpath.New("rpsql").AtMapKey("replicas"), knownvalue.Int32Exact(1)),
+					statecheck.ExpectKnownValue(clusterAddr, tfjsonpath.New("rpsql").AtMapKey("url"), knownvalue.StringExact("")),
+					idPreserved.AddStateValue(clusterAddr, tfjsonpath.New("id")),
+				}),
+			// Enable in place: url is re-derived to the provisioned endpoint.
+			integration.UpdateLeafStep(clusterAddr,
+				awsDedicatedConfig(name, `rpsql = { enabled = true }`),
+				[]statecheck.StateCheck{
+					statecheck.ExpectKnownValue(clusterAddr, tfjsonpath.New("rpsql").AtMapKey("enabled"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(clusterAddr, tfjsonpath.New("rpsql").AtMapKey("url"), knownvalue.StringExact(mockURL)),
+					idPreserved.AddStateValue(clusterAddr, tfjsonpath.New("id")),
+				}),
+			// Scale replicas in place.
+			integration.UpdateLeafStep(clusterAddr,
+				awsDedicatedConfig(name, `rpsql = { enabled = true, replicas = 3 }`),
+				[]statecheck.StateCheck{
+					statecheck.ExpectKnownValue(clusterAddr, tfjsonpath.New("rpsql").AtMapKey("replicas"), knownvalue.Int32Exact(3)),
+					statecheck.ExpectKnownValue(clusterAddr, tfjsonpath.New("rpsql").AtMapKey("url"), knownvalue.StringExact(mockURL)),
 					idPreserved.AddStateValue(clusterAddr, tfjsonpath.New("id")),
 				}),
 		},
@@ -1564,7 +1617,7 @@ func TestIntegration_Cluster_RequiresReplace_CMR_GCP_Block(t *testing.T) {
 		ProtoV6ProviderFactories: factories,
 		Steps: []resource.TestStep{
 			integration.CreateStep(clusterAddr,
-				gcpBYOVPCConfig(name, subnetNameA),
+				gcpBYOVPCConfig(name, subnetNameA, "psc-nat-subnet-test"),
 				[]statecheck.StateCheck{
 					statecheck.ExpectKnownValue(clusterAddr,
 						tfjsonpath.New("customer_managed_resources").AtMapKey("gcp").AtMapKey("subnet").AtMapKey("name"),
@@ -1573,7 +1626,7 @@ func TestIntegration_Cluster_RequiresReplace_CMR_GCP_Block(t *testing.T) {
 					idChanged.AddStateValue(clusterAddr, tfjsonpath.New("id")),
 				}),
 			integration.RequiresReplaceStep(clusterAddr,
-				gcpBYOVPCConfig(name, subnetNameB),
+				gcpBYOVPCConfig(name, subnetNameB, "psc-nat-subnet-test"),
 				[]statecheck.StateCheck{
 					statecheck.ExpectKnownValue(clusterAddr,
 						tfjsonpath.New("customer_managed_resources").AtMapKey("gcp").AtMapKey("subnet").AtMapKey("name"),
@@ -2271,6 +2324,30 @@ func TestIntegration_Cluster_OptionalComputed_CloudStorageSkipDestroy(t *testing
 			}),
 			integration.UpdateLeafStep(clusterAddr, setFalse, []statecheck.StateCheck{
 				statecheck.ExpectKnownValue(clusterAddr, skipPath, knownvalue.Bool(false)),
+			}),
+		},
+	})
+}
+
+// TestIntegration_Cluster_NullPscNatSubnetName_Repro omits psc_nat_subnet_name
+// from the GCP CMR block; the Optional-only string leaf must stay null across
+// create and re-apply rather than materializing an empty string.
+func TestIntegration_Cluster_NullPscNatSubnetName_Repro(t *testing.T) {
+	_, factories := clusterSetup(t)
+
+	const name = "tfrp-mock-cl-nullpsc"
+	cfg := gcpBYOVPCConfig(name, "tfrp-subnet-nullpsc", "")
+
+	pscPath := tfjsonpath.New("customer_managed_resources").AtMapKey("gcp").AtMapKey("psc_nat_subnet_name")
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: factories,
+		Steps: []resource.TestStep{
+			integration.CreateStep(clusterAddr, cfg, []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(clusterAddr, pscPath, knownvalue.Null()),
+			}),
+			integration.NoopReapplyStep(clusterAddr, cfg, []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(clusterAddr, pscPath, knownvalue.Null()),
 			}),
 		},
 	})

--- a/redpanda/resources/cluster/proto_validator_gen.go
+++ b/redpanda/resources/cluster/proto_validator_gen.go
@@ -70,5 +70,5 @@ func (protoValidator) ValidateResource(ctx context.Context, req resource.Validat
 	if eDiags.HasError() {
 		return
 	}
-	resp.Diagnostics.Append(rpvalidate.Validate(path.Empty(), payload)...)
+	resp.Diagnostics.Append(rpvalidate.Validate(path.Empty(), payload.GetCluster())...)
 }

--- a/redpanda/resources/cluster/proto_validator_gen.go
+++ b/redpanda/resources/cluster/proto_validator_gen.go
@@ -70,5 +70,6 @@ func (protoValidator) ValidateResource(ctx context.Context, req resource.Validat
 	if eDiags.HasError() {
 		return
 	}
-	resp.Diagnostics.Append(rpvalidate.Validate(path.Empty(), payload.GetCluster())...)
+	resp.Diagnostics.Append(rpvalidate.Validate(path.Empty(), payload.GetCluster(),
+		"rpsql")...)
 }

--- a/redpanda/resources/cluster/resource_cluster.go
+++ b/redpanda/resources/cluster/resource_cluster.go
@@ -34,6 +34,7 @@ import (
 	"github.com/redpanda-data/terraform-provider-redpanda/redpanda/config"
 	clustermodel "github.com/redpanda-data/terraform-provider-redpanda/redpanda/models/cluster"
 	"github.com/redpanda-data/terraform-provider-redpanda/redpanda/utils"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
 var (
@@ -195,6 +196,9 @@ func (c *Cluster) Update(ctx context.Context, req resource.UpdateRequest, resp *
 		return
 	}
 	diffedPayload, mask := utils.GenerateProtobufDiffAndUpdateMask(planPayload, statePayload)
+	// The public-API mapper recognizes rpsql.enabled / rpsql.replicas but not
+	// the top-level "rpsql" path the diff emits, so expand it before the request.
+	expandRpsqlPath(mask)
 	diffedPayload.Id = planPayload.Id
 	updateReq := &controlplanev1.UpdateClusterRequest{
 		Cluster:    diffedPayload,
@@ -232,6 +236,23 @@ func (c *Cluster) Update(ctx context.Context, req resource.UpdateRequest, resp *
 	}
 	tflog.Info(ctx, "cluster updated", map[string]any{"cluster_id": plan.ID.ValueString()})
 	resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)
+}
+
+// expandRpsqlPath rewrites a top-level "rpsql" update-mask path into the
+// granular rpsql.enabled / rpsql.replicas paths the public-API mapper accepts.
+func expandRpsqlPath(fm *fieldmaskpb.FieldMask) {
+	if fm == nil {
+		return
+	}
+	out := make([]string, 0, len(fm.Paths)+1)
+	for _, p := range fm.Paths {
+		if p == "rpsql" {
+			out = append(out, "rpsql.enabled", "rpsql.replicas")
+			continue
+		}
+		out = append(out, p)
+	}
+	fm.Paths = out
 }
 
 // Delete deletes the Cluster resource.

--- a/redpanda/resources/cluster/schema.yaml
+++ b/redpanda/resources/cluster/schema.yaml
@@ -416,6 +416,28 @@ kafka_connect:
     enabled:
       default: false
 
+rpsql:
+  # Defer the message CEL rule (replicas>=1 when enabled) to apply: it runs on
+  # raw config, before the replicas Default, so it would falsely reject configs
+  # relying on the default (cf. user.mechanism).
+  skip_proto_validation: true
+  fields:
+    # Default seeds on create; UseStateForUnknown carries the value across
+    # updates when omitted (else replicas plans <1 and trips the CEL rule).
+    enabled:
+      default: false
+      plan_modifiers: [UseStateForUnknown]
+    replicas:
+      default: 1
+      plan_modifiers: [UseStateForUnknown]
+    url:
+      computed_only: true
+      # Empty while disabled, set by the server on enable. No state-pin modifier:
+      # it would pin "" across the enable transition and trip inconsistent-result.
+      plan_modifiers: [None]
+    zones:
+      exclude: true
+
 maintenance_window_config:
   fields:
     anytime:
@@ -536,8 +558,6 @@ ai_gateway:
 
 # --- New proto fields (auto-added by schemagen -todo) ---
 adp_api:
-  todo: true
-rpsql:
   todo: true
 sandbox:
   todo: true

--- a/redpanda/resources/cluster/schema_resource_gen.go
+++ b/redpanda/resources/cluster/schema_resource_gen.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
@@ -1055,6 +1056,33 @@ func ResourceClusterSchema(ctx context.Context) schema.Schema {
 				Optional:      true,
 				Computed:      true,
 				PlanModifiers: []planmodifier.Int32{int32planmodifier.UseStateForUnknown()},
+			},
+
+			"rpsql": schema.SingleNestedAttribute{
+				Description:   "Rpsql configuration",
+				Optional:      true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.Object{objectplanmodifier.UseStateForUnknown()},
+				Attributes: map[string]schema.Attribute{
+					"enabled": schema.BoolAttribute{
+						Description:   "Whether Rpsql is enabled",
+						Optional:      true,
+						Computed:      true,
+						Default:       booldefault.StaticBool(false),
+						PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
+					},
+					"replicas": schema.Int32Attribute{
+						Description:   "Replicas",
+						Optional:      true,
+						Computed:      true,
+						Default:       int32default.StaticInt32(1),
+						PlanModifiers: []planmodifier.Int32{int32planmodifier.UseStateForUnknown()},
+					},
+					"url": schema.StringAttribute{
+						Description: "Rpsql URL",
+						Computed:    true,
+					},
+				},
 			},
 
 			"schema_registry": schema.SingleNestedAttribute{

--- a/redpanda/resources/network/proto_validator_gen.go
+++ b/redpanda/resources/network/proto_validator_gen.go
@@ -70,5 +70,5 @@ func (protoValidator) ValidateResource(ctx context.Context, req resource.Validat
 	if eDiags.HasError() {
 		return
 	}
-	resp.Diagnostics.Append(rpvalidate.Validate(path.Empty(), payload)...)
+	resp.Diagnostics.Append(rpvalidate.Validate(path.Empty(), payload.GetNetwork())...)
 }

--- a/redpanda/resources/pipeline/proto_validator_gen.go
+++ b/redpanda/resources/pipeline/proto_validator_gen.go
@@ -70,7 +70,7 @@ func (protoValidator) ValidateResource(ctx context.Context, req resource.Validat
 	if eDiags.HasError() {
 		return
 	}
-	resp.Diagnostics.Append(rpvalidate.Validate(path.Empty(), payload,
+	resp.Diagnostics.Append(rpvalidate.Validate(path.Empty(), payload.GetPipeline(),
 		"resources.cpu_shares",
 		"resources.memory_shares")...)
 }

--- a/redpanda/resources/resourcegroup/proto_validator_gen.go
+++ b/redpanda/resources/resourcegroup/proto_validator_gen.go
@@ -70,5 +70,5 @@ func (protoValidator) ValidateResource(ctx context.Context, req resource.Validat
 	if eDiags.HasError() {
 		return
 	}
-	resp.Diagnostics.Append(rpvalidate.Validate(path.Empty(), payload)...)
+	resp.Diagnostics.Append(rpvalidate.Validate(path.Empty(), payload.GetResourceGroup())...)
 }

--- a/redpanda/resources/role/proto_validator_gen.go
+++ b/redpanda/resources/role/proto_validator_gen.go
@@ -70,5 +70,5 @@ func (protoValidator) ValidateResource(ctx context.Context, req resource.Validat
 	if eDiags.HasError() {
 		return
 	}
-	resp.Diagnostics.Append(rpvalidate.Validate(path.Empty(), payload)...)
+	resp.Diagnostics.Append(rpvalidate.Validate(path.Empty(), payload.GetRole())...)
 }

--- a/redpanda/resources/serverlesscluster/proto_validator_gen.go
+++ b/redpanda/resources/serverlesscluster/proto_validator_gen.go
@@ -70,5 +70,5 @@ func (protoValidator) ValidateResource(ctx context.Context, req resource.Validat
 	if eDiags.HasError() {
 		return
 	}
-	resp.Diagnostics.Append(rpvalidate.Validate(path.Empty(), payload)...)
+	resp.Diagnostics.Append(rpvalidate.Validate(path.Empty(), payload.GetServerlessCluster())...)
 }

--- a/redpanda/resources/serverlessprivatelink/proto_validator_gen.go
+++ b/redpanda/resources/serverlessprivatelink/proto_validator_gen.go
@@ -70,5 +70,5 @@ func (protoValidator) ValidateResource(ctx context.Context, req resource.Validat
 	if eDiags.HasError() {
 		return
 	}
-	resp.Diagnostics.Append(rpvalidate.Validate(path.Empty(), payload)...)
+	resp.Diagnostics.Append(rpvalidate.Validate(path.Empty(), payload.GetServerlessPrivateLink())...)
 }

--- a/redpanda/resources/serviceaccount/proto_validator_gen.go
+++ b/redpanda/resources/serviceaccount/proto_validator_gen.go
@@ -70,5 +70,5 @@ func (protoValidator) ValidateResource(ctx context.Context, req resource.Validat
 	if eDiags.HasError() {
 		return
 	}
-	resp.Diagnostics.Append(rpvalidate.Validate(path.Empty(), payload)...)
+	resp.Diagnostics.Append(rpvalidate.Validate(path.Empty(), payload.GetServiceAccount())...)
 }

--- a/redpanda/resources/shadowlink/proto_validator_gen.go
+++ b/redpanda/resources/shadowlink/proto_validator_gen.go
@@ -77,5 +77,5 @@ func (protoValidator) ValidateResource(ctx context.Context, req resource.Validat
 		resp.Diagnostics.Append(hDiags...)
 		return
 	}
-	resp.Diagnostics.Append(rpvalidate.Validate(path.Empty(), payload)...)
+	resp.Diagnostics.Append(rpvalidate.Validate(path.Empty(), payload.GetShadowLink())...)
 }

--- a/redpanda/resources/testdata/cluster_resource_schema.golden
+++ b/redpanda/resources/testdata/cluster_resource_schema.golden
@@ -913,6 +913,30 @@ attributes:
       required: true
       plan_modifiers:
         - stringplanmodifier.requiresReplaceIfModifier
+    - name: rpsql
+      type: SingleNestedAttribute
+      optional: true
+      computed: true
+      plan_modifiers:
+        - objectplanmodifier.useStateForUnknownModifier
+      attributes:
+        - name: enabled
+          type: BoolAttribute
+          optional: true
+          computed: true
+          plan_modifiers:
+            - boolplanmodifier.useStateForUnknownModifier
+          default: booldefault.staticBoolDefault
+        - name: replicas
+          type: Int32Attribute
+          optional: true
+          computed: true
+          plan_modifiers:
+            - int32planmodifier.useStateForUnknownModifier
+          default: int32default.staticInt32Default
+        - name: url
+          type: StringAttribute
+          computed: true
     - name: schema_registry
       type: SingleNestedAttribute
       optional: true

--- a/redpanda/resources/topic/proto_validator_gen.go
+++ b/redpanda/resources/topic/proto_validator_gen.go
@@ -70,5 +70,5 @@ func (protoValidator) ValidateResource(ctx context.Context, req resource.Validat
 	if eDiags.HasError() {
 		return
 	}
-	resp.Diagnostics.Append(rpvalidate.Validate(path.Empty(), payload)...)
+	resp.Diagnostics.Append(rpvalidate.Validate(path.Empty(), payload.GetTopic())...)
 }

--- a/redpanda/resources/topic/resource_topic_test.go
+++ b/redpanda/resources/topic/resource_topic_test.go
@@ -129,7 +129,6 @@ func TestUnit_Topic_Create(t *testing.T) {
 		},
 		{
 			// Server says "no" with retriable: false metadata; provider must not retry.
-			// Regression guard for the dropped "topic authorization not ready" retry.
 			name: "PermissionDenied fails fast, no retry",
 			input: topicmodel.ResourceModel{
 				Name:              types.StringValue("denied-topic"),

--- a/redpanda/resources/user/proto_validator_gen.go
+++ b/redpanda/resources/user/proto_validator_gen.go
@@ -70,7 +70,7 @@ func (protoValidator) ValidateResource(ctx context.Context, req resource.Validat
 	if eDiags.HasError() {
 		return
 	}
-	resp.Diagnostics.Append(rpvalidate.Validate(path.Empty(), payload,
+	resp.Diagnostics.Append(rpvalidate.Validate(path.Empty(), payload.GetUser(),
 		"mechanism",
 		"password")...)
 }


### PR DESCRIPTION
https://github.com/redpanda-data/terraform-provider-redpanda/pull/345

Also fixes a very silly schemagen bug that was causing protovalidate not to fire because it was being called on the wrong layer. Validations were passing because there weren't null tests in place to show nothing was happening.  