### PR TITLE
fix(topic): report user value for broker noop configs (max.compaction.lag.ms)

### DIFF
--- a/redpanda/resources/topic/resource_topic.go
+++ b/redpanda/resources/topic/resource_topic.go
@@ -18,6 +18,7 @@ package topic
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	"buf.build/gen/go/redpandadata/dataplane/grpc/go/redpanda/api/dataplane/v1/dataplanev1grpc"
@@ -506,6 +507,31 @@ func filterDynamicConfig(configs []*dataplanev1.Topic_Configuration) []*dataplan
 	return filtered
 }
 
+// brokerNoopConfigs mirrors Redpanda's allowlist_topic_noop_confs: topic
+// configs the broker accepts, ignores, and may echo back with a normalized
+// value (e.g. max.compaction.lag.ms = LONG_MAX clamped to the max chrono
+// duration in ms). For these keys mergeWithPlannedConfig reports the user's
+// planned value so Terraform doesn't raise "inconsistent result after apply".
+//
+// Source (SHA-pinned): https://github.com/redpanda-data/redpanda/blob/62cf52867a72dd291a35b8728794ac5800d4b4b8/src/v/kafka/server/handlers/topics/types.h#L128-L147
+var brokerNoopConfigs = []string{
+	"unclean.leader.election.enable",
+	"message.downconversion.enable",
+	"segment.index.bytes",
+	"segment.jitter.ms",
+	"min.insync.replicas",
+	"min.compaction.lag.ms",
+	"message.timestamp.difference.max.ms",
+	"message.format.version",
+	"max.compaction.lag.ms",
+	"leader.replication.throttled.replicas",
+	"index.interval.bytes",
+	"follower.replication.throttled.replicas",
+	"flush.messages",
+	"file.delete.delay.ms",
+	"preallocate",
+}
+
 // mergeWithPlannedConfig ensures that any configuration keys the user
 // explicitly set in their Terraform config are preserved in the result, even
 // if the server reports them with a non-dynamic source (e.g. when the user-set
@@ -578,6 +604,29 @@ func mergeWithPlannedConfig(dynamicConfigs, allConfigs []*dataplanev1.Topic_Conf
 			Source: dataplanev1.ConfigSource_CONFIG_SOURCE_DYNAMIC_TOPIC_CONFIG,
 		})
 		present[key] = true
+	}
+
+	// prevent inconsistency by keeping broker noop configs to user value
+	for i, cfg := range filtered {
+		if cfg == nil {
+			continue
+		}
+		if !slices.Contains(brokerNoopConfigs, cfg.Name) {
+			continue
+		}
+		planString, ok := planned.Elements()[cfg.Name].(types.String)
+		if !ok || planString.IsNull() || planString.IsUnknown() {
+			continue
+		}
+		val := planString.ValueString()
+		if cfg.Value != nil && *cfg.Value == val {
+			continue
+		}
+		filtered[i] = &dataplanev1.Topic_Configuration{
+			Name:   cfg.Name,
+			Value:  &val,
+			Source: cfg.Source,
+		}
 	}
 	return filtered
 }

--- a/redpanda/resources/topic/resource_topic_test.go
+++ b/redpanda/resources/topic/resource_topic_test.go
@@ -868,6 +868,50 @@ func TestUnit_Topic_MergeWithPlannedConfig(t *testing.T) {
 			"the dynamic-source entry should win over a duplicate in allConfigs")
 	})
 
+	t.Run("broker clamps a noop config — planned value wins", func(t *testing.T) {
+		dynamic := []*dataplanev1.Topic_Configuration{
+			mkCfg("compression.type", "gzip"),
+			mkCfg("max.compaction.lag.ms", "9223372036854"),
+		}
+		planned := mkPlanned(map[string]string{
+			"compression.type":      "gzip",
+			"max.compaction.lag.ms": "9223372036854775807",
+		})
+
+		got := mergeWithPlannedConfig(dynamic, dynamic, planned)
+
+		assert.ElementsMatch(t, []string{"compression.type", "max.compaction.lag.ms"}, names(got),
+			"both keys must be present")
+		assert.Equal(t, "9223372036854775807", valueOf(got, "max.compaction.lag.ms"),
+			"a noop config whose broker read-back differs must report the planned value, not the clamped broker value")
+	})
+
+	t.Run("every broker noop config is plan-echoed when read-back differs", func(t *testing.T) {
+		for _, name := range brokerNoopConfigs {
+			dynamic := []*dataplanev1.Topic_Configuration{mkCfg(name, "broker-normalized")}
+			planned := mkPlanned(map[string]string{name: "user-value"})
+
+			got := mergeWithPlannedConfig(dynamic, dynamic, planned)
+
+			assert.Equal(t, "user-value", valueOf(got, name),
+				"%s is in the broker noop allowlist and must report the planned value", name)
+		}
+	})
+
+	t.Run("a non-noop key whose broker value differs — broker value wins", func(t *testing.T) {
+		dynamic := []*dataplanev1.Topic_Configuration{
+			mkCfg("flush.ms", "9223372036854"),
+		}
+		planned := mkPlanned(map[string]string{
+			"flush.ms": "9223372036854775807",
+		})
+
+		got := mergeWithPlannedConfig(dynamic, dynamic, planned)
+
+		assert.Equal(t, "9223372036854", valueOf(got, "flush.ms"),
+			"flush.ms is honored by the broker (not a noop config); its read-back value must win")
+	})
+
 	t.Run("empty dynamic + planned keys present in allConfigs — all reinstated", func(t *testing.T) {
 		all := []*dataplanev1.Topic_Configuration{
 			mkStaticCfg("compression.type", "producer"),

--- a/redpanda/tests/runner_test.go
+++ b/redpanda/tests/runner_test.go
@@ -439,6 +439,48 @@ func testRunner(ctx context.Context, name, rename, version, testFile string, cus
 		)
 	}
 
+	// max.compaction.lag.ms regression (issue #355): the broker accepts this
+	// noop config, ignores it, and echoes back a clamped value (LONG_MAX is
+	// stored as the max chrono duration in ms, 9223372036854). The provider
+	// must report the user's value so apply does not fail with "inconsistent
+	// result after apply" and the re-plan is empty. Pair the LONG_MAX step with
+	// a flip back to the basic config (broker reports the unset key with a
+	// non-dynamic source, so it is filtered out of state).
+	if hasTopic {
+		longMaxVars := make(map[string]config.Variable)
+		maps.Copy(longMaxVars, fieldMutationVars)
+		longMaxVars["topic_configuration"] = config.MapVariable(map[string]config.Variable{
+			"cleanup.policy":        config.StringVariable("delete"),
+			"retention.ms":          config.StringVariable("3600000"),
+			"max.compaction.lag.ms": config.StringVariable("9223372036854775807"),
+		})
+
+		steps = append(steps,
+			resource.TestStep{
+				ConfigDirectory:          config.StaticDirectory(testFile),
+				ConfigVariables:          longMaxVars,
+				ProtoV6ProviderFactories: acc.ProtoV6Factories,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(acc.TopicResourceName, "configuration.max.compaction.lag.ms", "9223372036854775807"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+			},
+			resource.TestStep{
+				ConfigDirectory:          config.StaticDirectory(testFile),
+				ConfigVariables:          fieldMutationVars,
+				ProtoV6ProviderFactories: acc.ProtoV6Factories,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr(acc.TopicResourceName, "configuration.max.compaction.lag.ms"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+			},
+		)
+	}
+
 	zonesSentinelVars := make(map[string]config.Variable)
 	maps.Copy(zonesSentinelVars, fieldMutationVars)
 	zonesSentinelVars["zones"] = config.ListVariable(


### PR DESCRIPTION
Fixes #355: for Redpanda noop topic configs like `max.compaction.lag.ms`, which the broker accepts but normalizes on read-back, report the user's planned value so apply doesn't produce an inconsistent result.