### PR TITLE
feat(cluster): add redpanda_connect.allowed_destination_cidr_ports

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -202,6 +202,7 @@ steps:
   - label: test_upgrade
     key: test_upgrade
     if: build.tag == null && build.pull_request.labels includes 'ci-ready-upgrade'
+    timeout_in_minutes: 240
     command: |
       ./taskw test:upgrade
     plugins:

--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -43,6 +43,7 @@ Cluster data source
 - `network_id` (String) Network ID where cluster is placed.
 - `prometheus` (Attributes) Prometheus metrics endpoint properties. (see [below for nested schema](#nestedatt--prometheus))
 - `read_replica_cluster_ids` (List of String) IDs of clusters which may create read-only topics from this cluster.
+- `redpanda_connect` (Attributes) Cluster's Redpanda Connect properties. (see [below for nested schema](#nestedatt--redpanda_connect))
 - `redpanda_console` (Attributes) Cluster's Redpanda Console properties. (see [below for nested schema](#nestedatt--redpanda_console))
 - `redpanda_version` (String) Redpanda Version
 - `region` (String) Region represents the name of the region where the cluster will be provisioned.
@@ -351,6 +352,9 @@ Read-Only:
 - `gke_service_account` (Attributes) GCP service account. (see [below for nested schema](#nestedatt--customer_managed_resources--gcp--gke_service_account))
 - `psc_nat_subnet_name` (String) NAT subnet name if GCP Private Service Connect (a.k.a Private Link) is enabled. If it is used for PSC v1, use psc_v2_nat_subnet_name to set NAT subnet name for PSC v2.
 - `redpanda_cluster_service_account` (Attributes) GCP service account. (see [below for nested schema](#nestedatt--customer_managed_resources--gcp--redpanda_cluster_service_account))
+- `rpsql_api_service_account` (Attributes) Rpsql API Service Account configuration (see [below for nested schema](#nestedatt--customer_managed_resources--gcp--rpsql_api_service_account))
+- `rpsql_cloud_storage_bucket` (Attributes) Rpsql Cloud Storage Bucket configuration (see [below for nested schema](#nestedatt--customer_managed_resources--gcp--rpsql_cloud_storage_bucket))
+- `rpsql_service_account` (Attributes) Rpsql Service Account configuration (see [below for nested schema](#nestedatt--customer_managed_resources--gcp--rpsql_service_account))
 - `subnet` (Attributes) GCP subnet properties. See the official [GCP API reference](https://cloud.google.com/compute/docs/reference/rest/v1/subnetworks). (see [below for nested schema](#nestedatt--customer_managed_resources--gcp--subnet))
 - `tiered_storage_bucket` (Attributes) GCP storage bucket properties. (see [below for nested schema](#nestedatt--customer_managed_resources--gcp--tiered_storage_bucket))
 
@@ -392,6 +396,30 @@ Read-Only:
 Read-Only:
 
 - `email` (String) GCP service account email.
+
+
+<a id="nestedatt--customer_managed_resources--gcp--rpsql_api_service_account"></a>
+### Nested Schema for `customer_managed_resources.gcp.rpsql_api_service_account`
+
+Read-Only:
+
+- `email` (String) Email address for the rpsql API Service Account
+
+
+<a id="nestedatt--customer_managed_resources--gcp--rpsql_cloud_storage_bucket"></a>
+### Nested Schema for `customer_managed_resources.gcp.rpsql_cloud_storage_bucket`
+
+Read-Only:
+
+- `name` (String) Name of the rpsql Cloud Storage Bucket
+
+
+<a id="nestedatt--customer_managed_resources--gcp--rpsql_service_account"></a>
+### Nested Schema for `customer_managed_resources.gcp.rpsql_service_account`
+
+Read-Only:
+
+- `email` (String) Email address for the rpsql Service Account
 
 
 <a id="nestedatt--customer_managed_resources--gcp--subnet"></a>
@@ -598,6 +626,25 @@ Read-Only:
 Read-Only:
 
 - `url` (String) Prometheus API URL.
+
+
+<a id="nestedatt--redpanda_connect"></a>
+### Nested Schema for `redpanda_connect`
+
+Read-Only:
+
+- `allowed_destination_cidr_ports` (Attributes List) List of allowed Destination CIDR Ports (see [below for nested schema](#nestedatt--redpanda_connect--allowed_destination_cidr_ports))
+- `version` (String) Version of the Redpanda Connect engine running on the Cluster.
+
+<a id="nestedatt--redpanda_connect--allowed_destination_cidr_ports"></a>
+### Nested Schema for `redpanda_connect.allowed_destination_cidr_ports`
+
+Read-Only:
+
+- `cidr` (String) CIDR
+- `port_end` (Number) Port End
+- `port_start` (Number) Port Start
+
 
 
 <a id="nestedatt--redpanda_console"></a>

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -42,6 +42,7 @@ Enables the provisioning and management of Redpanda clusters on AWS and GCP. A c
 - `kafka_connect` (Attributes) Kafka Connect configuration (see [below for nested schema](#nestedatt--kafka_connect))
 - `maintenance_window_config` (Attributes) Resource describing the maintenance window configuration of a cluster. (see [below for nested schema](#nestedatt--maintenance_window_config))
 - `read_replica_cluster_ids` (List of String) IDs of clusters which may create read-only topics from this cluster. Must have at most 100 items. Items must be unique.
+- `redpanda_connect` (Attributes) Cluster's Redpanda Connect properties. (see [below for nested schema](#nestedatt--redpanda_connect))
 - `redpanda_node_count` (Number) Number of Redpanda broker nodes. Must be at least 0.
 - `redpanda_version` (String) Cluster's Redpanda version. Only `major.minor` semver is supported, e.g. `24.1`.
 - `rpsql` (Attributes) Rpsql configuration (see [below for nested schema](#nestedatt--rpsql))
@@ -405,6 +406,9 @@ Required:
 Optional:
 
 - `psc_nat_subnet_name` (String) NAT subnet name if GCP Private Service Connect (a.k.a Private Link) is enabled. If it is used for PSC v1, use psc_v2_nat_subnet_name to set NAT subnet name for PSC v2.
+- `rpsql_api_service_account` (Attributes) Rpsql API Service Account configuration (see [below for nested schema](#nestedatt--customer_managed_resources--gcp--rpsql_api_service_account))
+- `rpsql_cloud_storage_bucket` (Attributes) Rpsql Cloud Storage Bucket configuration (see [below for nested schema](#nestedatt--customer_managed_resources--gcp--rpsql_cloud_storage_bucket))
+- `rpsql_service_account` (Attributes) Rpsql Service Account configuration (see [below for nested schema](#nestedatt--customer_managed_resources--gcp--rpsql_service_account))
 
 <a id="nestedatt--customer_managed_resources--gcp--agent_service_account"></a>
 ### Nested Schema for `customer_managed_resources.gcp.agent_service_account`
@@ -479,6 +483,30 @@ Required:
 Required:
 
 - `name` (String) Name of GCP storage bucket. See the official [GCP documentation](https://cloud.google.com/storage/docs/buckets#naming) for naming restrictions. Length must be between 3 and 63. Must match pattern `^[a-z]([-_a-z0-9]*[a-z0-9])?$`.
+
+
+<a id="nestedatt--customer_managed_resources--gcp--rpsql_api_service_account"></a>
+### Nested Schema for `customer_managed_resources.gcp.rpsql_api_service_account`
+
+Required:
+
+- `email` (String) Email address for the rpsql API Service Account. Must be a valid email address.
+
+
+<a id="nestedatt--customer_managed_resources--gcp--rpsql_cloud_storage_bucket"></a>
+### Nested Schema for `customer_managed_resources.gcp.rpsql_cloud_storage_bucket`
+
+Required:
+
+- `name` (String) Name of the rpsql Cloud Storage Bucket. Length must be between 3 and 63. Must match pattern `^[a-z]([-_a-z0-9]*[a-z0-9])?$`.
+
+
+<a id="nestedatt--customer_managed_resources--gcp--rpsql_service_account"></a>
+### Nested Schema for `customer_managed_resources.gcp.rpsql_service_account`
+
+Required:
+
+- `email` (String) Email address for the rpsql Service Account. Must be a valid email address.
 
 
 
@@ -645,6 +673,31 @@ Optional:
 
 - `day_of_week` (String) Represents a day of the week. - MONDAY: Monday - TUESDAY: Tuesday - WEDNESDAY: Wednesday - THURSDAY: Thursday - FRIDAY: Friday - SATURDAY: Saturday - SUNDAY: Sunday
 - `hour_of_day` (Number) always UTC. Must be between 0 and 23 (inclusive).
+
+
+
+<a id="nestedatt--redpanda_connect"></a>
+### Nested Schema for `redpanda_connect`
+
+Optional:
+
+- `allowed_destination_cidr_ports` (Attributes List) List of allowed Destination CIDR Ports. Must have at most 16 items. (see [below for nested schema](#nestedatt--redpanda_connect--allowed_destination_cidr_ports))
+
+Read-Only:
+
+- `version` (String) Version of the Redpanda Connect engine running on the Cluster.
+
+<a id="nestedatt--redpanda_connect--allowed_destination_cidr_ports"></a>
+### Nested Schema for `redpanda_connect.allowed_destination_cidr_ports`
+
+Required:
+
+- `cidr` (String) CIDR. Must match pattern `^([0-9]{1,3}\.){3}[0-9]{1,3}/[0-9]{1,2}$`.
+- `port_start` (Number) Port Start. Must be between 1 and 65535 (inclusive).
+
+Optional:
+
+- `port_end` (Number) Port End. Must be at most 65535.
 
 
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.10
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260415201107-50325440f8f2.1
 	buf.build/gen/go/redpandadata/cloud/grpc/go v1.6.2-20260610153311-e662350dea1d.1
-	buf.build/gen/go/redpandadata/cloud/protocolbuffers/go v1.36.11-20260610153311-e662350dea1d.1
+	buf.build/gen/go/redpandadata/cloud/protocolbuffers/go v1.36.11-20260708124553-f44debf87dc9.1
 	buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.11-20260410204044-2088239db14c.1
 	buf.build/gen/go/redpandadata/dataplane/grpc/go v1.6.1-20260429204409-5d8d126492a6.1
 	buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.11-20260429204409-5d8d126492a6.1

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ buf.build/gen/go/grpc-ecosystem/grpc-gateway/protocolbuffers/go v1.36.11-2024061
 buf.build/gen/go/grpc-ecosystem/grpc-gateway/protocolbuffers/go v1.36.11-20240617172850-a48fcebcf8f1.1/go.mod h1:KAAU6zfI4aGOR/SiWil31PiNwdpo1SlqZidcB3z+sL0=
 buf.build/gen/go/redpandadata/cloud/grpc/go v1.6.2-20260610153311-e662350dea1d.1 h1:xVezT4IOLIFteVNqIwn/gqgdjGkX1n/JiQHUaYvMQSM=
 buf.build/gen/go/redpandadata/cloud/grpc/go v1.6.2-20260610153311-e662350dea1d.1/go.mod h1:dJx69mzj/a4l3+kgbdWJZbWTE9HpchtLVxMVnA+WRVk=
-buf.build/gen/go/redpandadata/cloud/protocolbuffers/go v1.36.11-20260610153311-e662350dea1d.1 h1:4Qirg63CDoxPYz74/p9tGgWsyTST1qtvhnNO+waJItY=
-buf.build/gen/go/redpandadata/cloud/protocolbuffers/go v1.36.11-20260610153311-e662350dea1d.1/go.mod h1:mGE2zkYxn5XVU1arq8iqAxy0Xy+MfkOsVKhTG+Prspw=
+buf.build/gen/go/redpandadata/cloud/protocolbuffers/go v1.36.11-20260708124553-f44debf87dc9.1 h1:HY5L4BoOc/pG/sUMG8WM7sGSqpFl+IuunvaJo6c8PUQ=
+buf.build/gen/go/redpandadata/cloud/protocolbuffers/go v1.36.11-20260708124553-f44debf87dc9.1/go.mod h1:mGE2zkYxn5XVU1arq8iqAxy0Xy+MfkOsVKhTG+Prspw=
 buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.36.11-20260323171043-6e06f84ad823.1 h1:AZVH8d9Xh0ar1BbxDiY+2urib65GfAcT8rPZfM++N/Q=
 buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.36.11-20260323171043-6e06f84ad823.1/go.mod h1:3w7EzexwlL6PIFGbbeKZ0yHfUlAmI0aBVzF/QoFb8Cg=
 buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.11-20260410204044-2088239db14c.1 h1:IOMxi1FaSGAz9c0CndhmvRF4GocB7M9TM8x6Ok+ZMeI=

--- a/internal/buf_dependencies.yaml
+++ b/internal/buf_dependencies.yaml
@@ -10,7 +10,7 @@
 
 cloudv2:
     remote: github.com/redpanda-data/cloudv2
-    sha: e5691f2955ac663bdb8f190dcac732653a8ec96b
+    sha: 174f85b16dd29b6fde95468be461ea81e5069d15
 console:
     remote: github.com/redpanda-data/console
     sha: 6ff1a55d3d67b07c4b8049b32f42d6dad85881db

--- a/internal/clustermask/expand.go
+++ b/internal/clustermask/expand.go
@@ -23,7 +23,7 @@ import "google.golang.org/protobuf/types/known/fieldmaskpb"
 
 // ExpandLeafPaths rewrites, in place, any top-level mask path listed in
 // LeafExpansions into its leaf paths. The control plane maps those fields
-// (rpsql, kafka_connect) only at leaf granularity, so sending the bare object
+// (kafka_connect, redpanda_connect, rpsql) only at leaf granularity, so sending the bare object
 // path silently drops the update. All other paths pass through unchanged.
 func ExpandLeafPaths(fm *fieldmaskpb.FieldMask) {
 	if fm == nil {

--- a/internal/clustermask/paths.go
+++ b/internal/clustermask/paths.go
@@ -49,6 +49,7 @@ var AcceptedTopLevel = map[string]bool{
 // granularity to the leaf paths to send instead. The diff emits the bare object
 // path; ExpandLeafPaths rewrites it to these before the UpdateCluster request.
 var LeafExpansions = map[string][]string{
-	"kafka_connect": {"kafka_connect.enabled"},
-	"rpsql":         {"rpsql.enabled", "rpsql.replicas", "rpsql.zones"},
+	"kafka_connect":    {"kafka_connect.enabled"},
+	"redpanda_connect": {"redpanda_connect.allowed_destination_cidr_ports"},
+	"rpsql":            {"rpsql.enabled", "rpsql.replicas", "rpsql.zones"},
 }

--- a/internal/clustermask/paths_test.go
+++ b/internal/clustermask/paths_test.go
@@ -23,7 +23,7 @@ import (
 // TestFixtureContract pins the hand-maintained cluster field-mask maps to the
 // shape the provider + mock depend on. AcceptedTopLevel is the union of no-dot
 // keys from cloudv2's pathMap and multiListenersPathMap (the latter contributes
-// kafka_api); LeafExpansions is the curated {rpsql, kafka_connect} set. An
+// kafka_api); LeafExpansions is the curated {rpsql, kafka_connect, redpanda_connect} set. An
 // accidental edit to paths.go fails here.
 func TestFixtureContract(t *testing.T) {
 	wantTop := []string{
@@ -44,8 +44,9 @@ func TestFixtureContract(t *testing.T) {
 	}
 
 	wantLeaf := map[string][]string{
-		"kafka_connect": {"kafka_connect.enabled"},
-		"rpsql":         {"rpsql.enabled", "rpsql.replicas", "rpsql.zones"},
+		"kafka_connect":    {"kafka_connect.enabled"},
+		"redpanda_connect": {"redpanda_connect.allowed_destination_cidr_ports"},
+		"rpsql":            {"rpsql.enabled", "rpsql.replicas", "rpsql.zones"},
 	}
 	if !reflect.DeepEqual(LeafExpansions, wantLeaf) {
 		t.Errorf("LeafExpansions = %v, want %v", LeafExpansions, wantLeaf)

--- a/internal/schemagen/flatten_expand_plan.go
+++ b/internal/schemagen/flatten_expand_plan.go
@@ -883,11 +883,22 @@ func planField(a *SchemaAttr, fc *FieldConfig, protoByName map[string]*ProtoFiel
 		attrTypesFn := nestedPrefix + pathToPascal(a.Name) + "AttrTypes"
 		flattenFn := "Flatten" + nestedPrefix + pathToPascal(a.Name)
 		expandFn := "Expand" + nestedPrefix + pathToPascal(a.Name)
-		if conv.FlattenExpr == "" {
-			conv.FlattenExpr = fmt.Sprintf(
-				"modelconv.ListFromObjectsWithDiags(ctx, proto.Get%s(), %s(), %s, &diags)",
-				conv.ProtoGoName, attrTypesFn, flattenFn,
-			)
+		if conv.FlattenExpr == "" && conv.FlattenStmt == "" {
+			if a.Optional {
+				// proto3 repeated erases empty-vs-absent on the wire: a planned
+				// [] reads back as nil and would flatten to null, tripping
+				// inconsistent-result. Carry a known-empty prev through.
+				conv.FlattenStmt = fmt.Sprintf(
+					"m.%s = modelconv.ListFromObjectsWithDiags(ctx, proto.Get%s(), %s(), %s, &diags)\n\tif prev != nil {\n\t\tm.%s = modelconv.ListCarryKnownEmpty(m.%s, prev.%s)\n\t}",
+					conv.GoName, conv.ProtoGoName, attrTypesFn, flattenFn,
+					conv.GoName, conv.GoName, conv.GoName,
+				)
+			} else {
+				conv.FlattenExpr = fmt.Sprintf(
+					"modelconv.ListFromObjectsWithDiags(ctx, proto.Get%s(), %s(), %s, &diags)",
+					conv.ProtoGoName, attrTypesFn, flattenFn,
+				)
+			}
 		}
 		if conv.ExpandExpr == "" {
 			conv.ExpandExpr = fmt.Sprintf(

--- a/internal/schemagen/testdata/list_message_conv.golden
+++ b/internal/schemagen/testdata/list_message_conv.golden
@@ -39,6 +39,9 @@ func Flatten(ctx context.Context, proto TopicResponse, prev *ResourceModel) (*Re
 	m := &ResourceModel{}
 	m.Name = types.StringValue(proto.GetName())
 	m.ReplicaAssignments = modelconv.ListFromObjectsWithDiags(ctx, proto.GetReplicaAssignments(), ReplicaAssignmentsAttrTypes(), FlattenReplicaAssignments, &diags)
+	if prev != nil {
+		m.ReplicaAssignments = modelconv.ListCarryKnownEmpty(m.ReplicaAssignments, prev.ReplicaAssignments)
+	}
 	return m, diags
 }
 

--- a/internal/testutil/mock/fakes/cluster.go
+++ b/internal/testutil/mock/fakes/cluster.go
@@ -199,6 +199,20 @@ func (f *ClusterFake) CreateCluster(_ context.Context, req *controlplanev1.Creat
 	if in.HasRpsql() {
 		cl.SetRpsql(rpsqlStatus(in.GetRpsql(), in.GetZones()))
 	}
+	if in.HasRedpandaConnect() {
+		src := in.GetRedpandaConnect()
+		ports := make([]*controlplanev1.Cluster_CidrPort, 0, len(src.GetAllowedDestinationCidrPorts()))
+		for _, p := range src.GetAllowedDestinationCidrPorts() {
+			ports = append(ports, &controlplanev1.Cluster_CidrPort{
+				Cidr:      p.GetCidr(),
+				PortStart: p.GetPortStart(),
+				PortEnd:   p.GetPortEnd(),
+			})
+		}
+		cl.SetRedpandaConnect(&controlplanev1.Cluster_RedpandaConnect{
+			AllowedDestinationCidrPorts: ports,
+		})
+	}
 	// Mirror the GCP-only intent input (gcp_enable_global_access_api_gateway on
 	// the write shape) onto the reported status field (different read-shape name).
 	if in.GetCloudProvider() == controlplanev1.CloudProvider_CLOUD_PROVIDER_GCP {
@@ -324,6 +338,28 @@ func (f *ClusterFake) UpdateCluster(_ context.Context, req *controlplanev1.Updat
 					GlobalAccessEnabled: spec.GetGlobalAccessEnabled(),
 					ConsumerAcceptList:  append([]*controlplanev1.GCPPrivateServiceConnectConsumer(nil), spec.GetConsumerAcceptList()...),
 				})
+			}
+		case "redpanda_connect.allowed_destination_cidr_ports":
+			// LeafExpansions sends this granular path for redpanda_connect updates.
+			// Copy the AllowedDestinationCidrPorts slice from the update payload.
+			// Use a non-nil (possibly empty) slice so the flatten sees an empty list
+			// rather than null when all entries are removed.
+			if upd.HasRedpandaConnect() {
+				src := upd.GetRedpandaConnect()
+				existing := cl.GetRedpandaConnect()
+				if existing == nil {
+					existing = &controlplanev1.Cluster_RedpandaConnect{}
+				}
+				ports := make([]*controlplanev1.Cluster_CidrPort, 0, len(src.GetAllowedDestinationCidrPorts()))
+				for _, p := range src.GetAllowedDestinationCidrPorts() {
+					ports = append(ports, &controlplanev1.Cluster_CidrPort{
+						Cidr:      p.GetCidr(),
+						PortStart: p.GetPortStart(),
+						PortEnd:   p.GetPortEnd(),
+					})
+				}
+				existing.AllowedDestinationCidrPorts = ports
+				cl.SetRedpandaConnect(existing)
 			}
 		case "gcp_enable_global_access_api_gateway":
 			// Write-shape intent maps onto the differently-named read-shape status.

--- a/redpanda/models/cluster/conv_gen.go
+++ b/redpanda/models/cluster/conv_gen.go
@@ -55,6 +55,7 @@ type ClusterResponse interface {
 	GetNetworkId() string
 	GetPrometheus() *controlplanev1.Cluster_Prometheus
 	GetReadReplicaClusterIds() []string
+	GetRedpandaConnect() *controlplanev1.Cluster_RedpandaConnect
 	GetRedpandaConsole() *controlplanev1.Cluster_RedpandaConsole
 	GetRedpandaNodeCount() int32
 	GetRegion() string
@@ -122,6 +123,7 @@ func Flatten(ctx context.Context, proto ClusterResponse, prev *ResourceModel) (*
 	m.KafkaAPI = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetKafkaApi(), func() *KafkaAPIModel { v, _ := prev.AsKafkaAPI(ctx); return v }(), KafkaAPIAttrTypes(), FlattenKafkaAPI, &diags)
 	m.KafkaConnect = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetKafkaConnect(), func() *KafkaConnectModel { v, _ := prev.AsKafkaConnect(ctx); return v }(), KafkaConnectAttrTypes(), FlattenKafkaConnect, &diags)
 	m.MaintenanceWindowConfig = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetMaintenanceWindowConfig(), func() *MaintenanceWindowConfigModel { v, _ := prev.AsMaintenanceWindowConfig(ctx); return v }(), MaintenanceWindowConfigAttrTypes(), FlattenMaintenanceWindowConfig, &diags)
+	m.RedpandaConnect = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetRedpandaConnect(), func() *RedpandaConnectModel { v, _ := prev.AsRedpandaConnect(ctx); return v }(), RedpandaConnectAttrTypes(), FlattenRedpandaConnect, &diags)
 	m.RedpandaNodeCount = types.Int32Value(proto.GetRedpandaNodeCount())
 	m.Rpsql = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetRpsql(), func() *RpsqlModel { v, _ := prev.AsRpsql(ctx); return v }(), RpsqlAttrTypes(), FlattenRpsql, &diags)
 	m.SchemaRegistry = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetSchemaRegistry(), func() *SchemaRegistryModel { v, _ := prev.AsSchemaRegistry(ctx); return v }(), SchemaRegistryAttrTypes(), FlattenSchemaRegistry, &diags)
@@ -217,6 +219,7 @@ func ExpandCreate(ctx context.Context, m *ResourceModel) (*controlplanev1.Create
 		KafkaApi:                        modelconv.ObjectToMessageWithDiags(ctx, m.KafkaAPI, ExpandCreateKafkaAPI, &diags),
 		KafkaConnect:                    modelconv.ObjectToMessageWithDiags(ctx, m.KafkaConnect, ExpandKafkaConnect, &diags),
 		MaintenanceWindowConfig:         modelconv.ObjectToMessageWithDiags(ctx, m.MaintenanceWindowConfig, ExpandMaintenanceWindowConfig, &diags),
+		RedpandaConnect:                 modelconv.ObjectToMessageWithDiags(ctx, m.RedpandaConnect, ExpandRedpandaConnect, &diags),
 		RedpandaNodeCount:               m.RedpandaNodeCount.ValueInt32(),
 		Rpsql:                           modelconv.ObjectToMessageWithDiags(ctx, m.Rpsql, ExpandRpsql, &diags),
 		SchemaRegistry:                  modelconv.ObjectToMessageWithDiags(ctx, m.SchemaRegistry, ExpandCreateSchemaRegistry, &diags),
@@ -248,6 +251,7 @@ func ExpandUpdate(ctx context.Context, m *ResourceModel) (*controlplanev1.Cluste
 		KafkaApi:                        modelconv.ObjectToMessageWithDiags(ctx, m.KafkaAPI, ExpandUpdateKafkaAPI, &diags),
 		KafkaConnect:                    modelconv.ObjectToMessageWithDiags(ctx, m.KafkaConnect, ExpandKafkaConnect, &diags),
 		MaintenanceWindowConfig:         modelconv.ObjectToMessageWithDiags(ctx, m.MaintenanceWindowConfig, ExpandMaintenanceWindowConfig, &diags),
+		RedpandaConnect:                 modelconv.ObjectToMessageWithDiags(ctx, m.RedpandaConnect, ExpandRedpandaConnect, &diags),
 		RedpandaNodeCount:               m.RedpandaNodeCount.ValueInt32(),
 		Rpsql:                           modelconv.ObjectToMessageWithDiags(ctx, m.Rpsql, ExpandRpsql, &diags),
 		SchemaRegistry:                  modelconv.ObjectToMessageWithDiags(ctx, m.SchemaRegistry, ExpandUpdateSchemaRegistry, &diags),
@@ -928,6 +932,18 @@ func FlattenCustomerManagedResourcesGCP(ctx context.Context, proto *controlplane
 	} else {
 		m.PscNatSubnetName = types.StringNull()
 	}
+	m.RpsqlAPIServiceAccount = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetRpsqlApiServiceAccount(), func() *CustomerManagedResourcesGCPRpsqlAPIServiceAccountModel {
+		v, _ := DecodeCustomerManagedResourcesGCPRpsqlAPIServiceAccount(ctx, prev)
+		return v
+	}(), CustomerManagedResourcesGCPRpsqlAPIServiceAccountAttrTypes(), FlattenCustomerManagedResourcesGCPRpsqlAPIServiceAccount, &diags)
+	m.RpsqlCloudStorageBucket = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetRpsqlCloudStorageBucket(), func() *CustomerManagedResourcesGCPRpsqlCloudStorageBucketModel {
+		v, _ := DecodeCustomerManagedResourcesGCPRpsqlCloudStorageBucket(ctx, prev)
+		return v
+	}(), CustomerManagedResourcesGCPRpsqlCloudStorageBucketAttrTypes(), FlattenCustomerManagedResourcesGCPRpsqlCloudStorageBucket, &diags)
+	m.RpsqlServiceAccount = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetRpsqlServiceAccount(), func() *CustomerManagedResourcesGCPRpsqlServiceAccountModel {
+		v, _ := DecodeCustomerManagedResourcesGCPRpsqlServiceAccount(ctx, prev)
+		return v
+	}(), CustomerManagedResourcesGCPRpsqlServiceAccountAttrTypes(), FlattenCustomerManagedResourcesGCPRpsqlServiceAccount, &diags)
 	return m, diags
 }
 
@@ -946,6 +962,9 @@ func ExpandCustomerManagedResourcesGCP(ctx context.Context, m *CustomerManagedRe
 		Subnet:                        modelconv.ObjectToMessageWithDiags(ctx, m.Subnet, ExpandCustomerManagedResourcesGCPSubnet, &diags),
 		TieredStorageBucket:           modelconv.ObjectToMessageWithDiags(ctx, m.TieredStorageBucket, ExpandCustomerManagedResourcesGCPTieredStorageBucket, &diags),
 		PscNatSubnetName:              m.PscNatSubnetName.ValueString(),
+		RpsqlApiServiceAccount:        modelconv.ObjectToMessageWithDiags(ctx, m.RpsqlAPIServiceAccount, ExpandCustomerManagedResourcesGCPRpsqlAPIServiceAccount, &diags),
+		RpsqlCloudStorageBucket:       modelconv.ObjectToMessageWithDiags(ctx, m.RpsqlCloudStorageBucket, ExpandCustomerManagedResourcesGCPRpsqlCloudStorageBucket, &diags),
+		RpsqlServiceAccount:           modelconv.ObjectToMessageWithDiags(ctx, m.RpsqlServiceAccount, ExpandCustomerManagedResourcesGCPRpsqlServiceAccount, &diags),
 	}
 	return out, diags
 }
@@ -1183,6 +1202,81 @@ func ExpandCustomerManagedResourcesGCPTieredStorageBucket(_ context.Context, m *
 	}
 	out := &controlplanev1.CustomerManagedGoogleCloudStorageBucket{
 		Name: m.Name.ValueString(),
+	}
+	return out, diags
+}
+
+// FlattenCustomerManagedResourcesGCPRpsqlAPIServiceAccount converts a single proto controlplanev1.GCPServiceAccount into the
+// corresponding nested model. The prev *CustomerManagedResourcesGCPRpsqlAPIServiceAccountModel arg carries forward
+// TF-only / sensitive / write-only fields and resolves the proto3
+// null-vs-empty ambiguity for Optional-only scalar leaves (Required leaves
+// flatten directly); pass nil when no prior nested state is available.
+func FlattenCustomerManagedResourcesGCPRpsqlAPIServiceAccount(_ context.Context, proto *controlplanev1.GCPServiceAccount, prev *CustomerManagedResourcesGCPRpsqlAPIServiceAccountModel) (CustomerManagedResourcesGCPRpsqlAPIServiceAccountModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	_ = prev
+	m := CustomerManagedResourcesGCPRpsqlAPIServiceAccountModel{}
+	m.Email = types.StringValue(proto.GetEmail())
+	return m, diags
+}
+
+// ExpandCustomerManagedResourcesGCPRpsqlAPIServiceAccount renders a nested model back into the proto type.
+func ExpandCustomerManagedResourcesGCPRpsqlAPIServiceAccount(_ context.Context, m *CustomerManagedResourcesGCPRpsqlAPIServiceAccountModel) (*controlplanev1.GCPServiceAccount, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if m == nil {
+		return nil, diags
+	}
+	out := &controlplanev1.GCPServiceAccount{
+		Email: m.Email.ValueString(),
+	}
+	return out, diags
+}
+
+// FlattenCustomerManagedResourcesGCPRpsqlCloudStorageBucket converts a single proto controlplanev1.CustomerManagedGoogleCloudStorageBucket into the
+// corresponding nested model. The prev *CustomerManagedResourcesGCPRpsqlCloudStorageBucketModel arg carries forward
+// TF-only / sensitive / write-only fields and resolves the proto3
+// null-vs-empty ambiguity for Optional-only scalar leaves (Required leaves
+// flatten directly); pass nil when no prior nested state is available.
+func FlattenCustomerManagedResourcesGCPRpsqlCloudStorageBucket(_ context.Context, proto *controlplanev1.CustomerManagedGoogleCloudStorageBucket, prev *CustomerManagedResourcesGCPRpsqlCloudStorageBucketModel) (CustomerManagedResourcesGCPRpsqlCloudStorageBucketModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	_ = prev
+	m := CustomerManagedResourcesGCPRpsqlCloudStorageBucketModel{}
+	m.Name = types.StringValue(proto.GetName())
+	return m, diags
+}
+
+// ExpandCustomerManagedResourcesGCPRpsqlCloudStorageBucket renders a nested model back into the proto type.
+func ExpandCustomerManagedResourcesGCPRpsqlCloudStorageBucket(_ context.Context, m *CustomerManagedResourcesGCPRpsqlCloudStorageBucketModel) (*controlplanev1.CustomerManagedGoogleCloudStorageBucket, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if m == nil {
+		return nil, diags
+	}
+	out := &controlplanev1.CustomerManagedGoogleCloudStorageBucket{
+		Name: m.Name.ValueString(),
+	}
+	return out, diags
+}
+
+// FlattenCustomerManagedResourcesGCPRpsqlServiceAccount converts a single proto controlplanev1.GCPServiceAccount into the
+// corresponding nested model. The prev *CustomerManagedResourcesGCPRpsqlServiceAccountModel arg carries forward
+// TF-only / sensitive / write-only fields and resolves the proto3
+// null-vs-empty ambiguity for Optional-only scalar leaves (Required leaves
+// flatten directly); pass nil when no prior nested state is available.
+func FlattenCustomerManagedResourcesGCPRpsqlServiceAccount(_ context.Context, proto *controlplanev1.GCPServiceAccount, prev *CustomerManagedResourcesGCPRpsqlServiceAccountModel) (CustomerManagedResourcesGCPRpsqlServiceAccountModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	_ = prev
+	m := CustomerManagedResourcesGCPRpsqlServiceAccountModel{}
+	m.Email = types.StringValue(proto.GetEmail())
+	return m, diags
+}
+
+// ExpandCustomerManagedResourcesGCPRpsqlServiceAccount renders a nested model back into the proto type.
+func ExpandCustomerManagedResourcesGCPRpsqlServiceAccount(_ context.Context, m *CustomerManagedResourcesGCPRpsqlServiceAccountModel) (*controlplanev1.GCPServiceAccount, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if m == nil {
+		return nil, diags
+	}
+	out := &controlplanev1.GCPServiceAccount{
+		Email: m.Email.ValueString(),
 	}
 	return out, diags
 }
@@ -2036,6 +2130,62 @@ func ExpandMaintenanceWindowConfigDayHour(_ context.Context, m *MaintenanceWindo
 	out := &controlplanev1.MaintenanceWindowConfig_DayHour{
 		DayOfWeek: enums.StringToDayOfWeek(m.DayOfWeek.ValueString()),
 		HourOfDay: m.HourOfDay.ValueInt32(),
+	}
+	return out, diags
+}
+
+// FlattenRedpandaConnect converts a single proto controlplanev1.Cluster_RedpandaConnect into the
+// corresponding nested model. The prev *RedpandaConnectModel arg carries forward
+// TF-only / sensitive / write-only fields and resolves the proto3
+// null-vs-empty ambiguity for Optional-only scalar leaves (Required leaves
+// flatten directly); pass nil when no prior nested state is available.
+func FlattenRedpandaConnect(ctx context.Context, proto *controlplanev1.Cluster_RedpandaConnect, prev *RedpandaConnectModel) (RedpandaConnectModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	_ = prev
+	m := RedpandaConnectModel{}
+	m.AllowedDestinationCidrPorts = modelconv.ListFromObjectsWithDiags(ctx, proto.GetAllowedDestinationCidrPorts(), RedpandaConnectAllowedDestinationCidrPortsAttrTypes(), FlattenRedpandaConnectAllowedDestinationCidrPorts, &diags)
+	m.Version = types.StringValue(proto.GetVersion())
+	return m, diags
+}
+
+// ExpandRedpandaConnect renders a nested model back into the proto type.
+func ExpandRedpandaConnect(ctx context.Context, m *RedpandaConnectModel) (*controlplanev1.Cluster_RedpandaConnect, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if m == nil {
+		return nil, diags
+	}
+	out := &controlplanev1.Cluster_RedpandaConnect{
+		AllowedDestinationCidrPorts: modelconv.ListToObjectsWithDiags(ctx, m.AllowedDestinationCidrPorts, ExpandRedpandaConnectAllowedDestinationCidrPorts, &diags),
+		Version:                     m.Version.ValueString(),
+	}
+	return out, diags
+}
+
+// FlattenRedpandaConnectAllowedDestinationCidrPorts converts a single proto controlplanev1.Cluster_CidrPort into the
+// corresponding nested model. The prev *RedpandaConnectAllowedDestinationCidrPortsModel arg carries forward
+// TF-only / sensitive / write-only fields and resolves the proto3
+// null-vs-empty ambiguity for Optional-only scalar leaves (Required leaves
+// flatten directly); pass nil when no prior nested state is available.
+func FlattenRedpandaConnectAllowedDestinationCidrPorts(_ context.Context, proto *controlplanev1.Cluster_CidrPort, prev *RedpandaConnectAllowedDestinationCidrPortsModel) (RedpandaConnectAllowedDestinationCidrPortsModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	_ = prev
+	m := RedpandaConnectAllowedDestinationCidrPortsModel{}
+	m.Cidr = types.StringValue(proto.GetCidr())
+	m.PortStart = types.Int32Value(proto.GetPortStart())
+	m.PortEnd = types.Int32Value(proto.GetPortEnd())
+	return m, diags
+}
+
+// ExpandRedpandaConnectAllowedDestinationCidrPorts renders a nested model back into the proto type.
+func ExpandRedpandaConnectAllowedDestinationCidrPorts(_ context.Context, m *RedpandaConnectAllowedDestinationCidrPortsModel) (*controlplanev1.Cluster_CidrPort, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if m == nil {
+		return nil, diags
+	}
+	out := &controlplanev1.Cluster_CidrPort{
+		Cidr:      m.Cidr.ValueString(),
+		PortStart: m.PortStart.ValueInt32(),
+		PortEnd:   m.PortEnd.ValueInt32(),
 	}
 	return out, diags
 }

--- a/redpanda/models/cluster/conv_gen.go
+++ b/redpanda/models/cluster/conv_gen.go
@@ -2144,6 +2144,9 @@ func FlattenRedpandaConnect(ctx context.Context, proto *controlplanev1.Cluster_R
 	_ = prev
 	m := RedpandaConnectModel{}
 	m.AllowedDestinationCidrPorts = modelconv.ListFromObjectsWithDiags(ctx, proto.GetAllowedDestinationCidrPorts(), RedpandaConnectAllowedDestinationCidrPortsAttrTypes(), FlattenRedpandaConnectAllowedDestinationCidrPorts, &diags)
+	if prev != nil {
+		m.AllowedDestinationCidrPorts = modelconv.ListCarryKnownEmpty(m.AllowedDestinationCidrPorts, prev.AllowedDestinationCidrPorts)
+	}
 	m.Version = types.StringValue(proto.GetVersion())
 	return m, diags
 }

--- a/redpanda/models/cluster/data_conv_gen.go
+++ b/redpanda/models/cluster/data_conv_gen.go
@@ -1066,6 +1066,18 @@ func FlattenDataCustomerManagedResourcesGCP(ctx context.Context, proto *controlp
 		v, _ := DecodeDataCustomerManagedResourcesGCPRedpandaClusterServiceAccount(ctx, prev)
 		return v
 	}(), DataCustomerManagedResourcesGCPRedpandaClusterServiceAccountAttrTypes(), FlattenDataCustomerManagedResourcesGCPRedpandaClusterServiceAccount, &diags)
+	m.RpsqlAPIServiceAccount = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetRpsqlApiServiceAccount(), func() *DataCustomerManagedResourcesGCPRpsqlAPIServiceAccountModel {
+		v, _ := DecodeDataCustomerManagedResourcesGCPRpsqlAPIServiceAccount(ctx, prev)
+		return v
+	}(), DataCustomerManagedResourcesGCPRpsqlAPIServiceAccountAttrTypes(), FlattenDataCustomerManagedResourcesGCPRpsqlAPIServiceAccount, &diags)
+	m.RpsqlCloudStorageBucket = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetRpsqlCloudStorageBucket(), func() *DataCustomerManagedResourcesGCPRpsqlCloudStorageBucketModel {
+		v, _ := DecodeDataCustomerManagedResourcesGCPRpsqlCloudStorageBucket(ctx, prev)
+		return v
+	}(), DataCustomerManagedResourcesGCPRpsqlCloudStorageBucketAttrTypes(), FlattenDataCustomerManagedResourcesGCPRpsqlCloudStorageBucket, &diags)
+	m.RpsqlServiceAccount = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetRpsqlServiceAccount(), func() *DataCustomerManagedResourcesGCPRpsqlServiceAccountModel {
+		v, _ := DecodeDataCustomerManagedResourcesGCPRpsqlServiceAccount(ctx, prev)
+		return v
+	}(), DataCustomerManagedResourcesGCPRpsqlServiceAccountAttrTypes(), FlattenDataCustomerManagedResourcesGCPRpsqlServiceAccount, &diags)
 	m.Subnet = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetSubnet(), func() *DataCustomerManagedResourcesGCPSubnetModel {
 		v, _ := DecodeDataCustomerManagedResourcesGCPSubnet(ctx, prev)
 		return v
@@ -1090,6 +1102,9 @@ func ExpandDataCustomerManagedResourcesGCP(ctx context.Context, m *DataCustomerM
 		GkeServiceAccount:             modelconv.ObjectToMessageWithDiags(ctx, m.GkeServiceAccount, ExpandDataCustomerManagedResourcesGCPGkeServiceAccount, &diags),
 		PscNatSubnetName:              m.PscNatSubnetName.ValueString(),
 		RedpandaClusterServiceAccount: modelconv.ObjectToMessageWithDiags(ctx, m.RedpandaClusterServiceAccount, ExpandDataCustomerManagedResourcesGCPRedpandaClusterServiceAccount, &diags),
+		RpsqlApiServiceAccount:        modelconv.ObjectToMessageWithDiags(ctx, m.RpsqlAPIServiceAccount, ExpandDataCustomerManagedResourcesGCPRpsqlAPIServiceAccount, &diags),
+		RpsqlCloudStorageBucket:       modelconv.ObjectToMessageWithDiags(ctx, m.RpsqlCloudStorageBucket, ExpandDataCustomerManagedResourcesGCPRpsqlCloudStorageBucket, &diags),
+		RpsqlServiceAccount:           modelconv.ObjectToMessageWithDiags(ctx, m.RpsqlServiceAccount, ExpandDataCustomerManagedResourcesGCPRpsqlServiceAccount, &diags),
 		Subnet:                        modelconv.ObjectToMessageWithDiags(ctx, m.Subnet, ExpandDataCustomerManagedResourcesGCPSubnet, &diags),
 		TieredStorageBucket:           modelconv.ObjectToMessageWithDiags(ctx, m.TieredStorageBucket, ExpandDataCustomerManagedResourcesGCPTieredStorageBucket, &diags),
 	}
@@ -1211,6 +1226,81 @@ func FlattenDataCustomerManagedResourcesGCPRedpandaClusterServiceAccount(_ conte
 
 // ExpandDataCustomerManagedResourcesGCPRedpandaClusterServiceAccount renders a nested model back into the proto type.
 func ExpandDataCustomerManagedResourcesGCPRedpandaClusterServiceAccount(_ context.Context, m *DataCustomerManagedResourcesGCPRedpandaClusterServiceAccountModel) (*controlplanev1.GCPServiceAccount, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if m == nil {
+		return nil, diags
+	}
+	out := &controlplanev1.GCPServiceAccount{
+		Email: m.Email.ValueString(),
+	}
+	return out, diags
+}
+
+// FlattenDataCustomerManagedResourcesGCPRpsqlAPIServiceAccount converts a single proto controlplanev1.GCPServiceAccount into the
+// corresponding nested model. The prev *DataCustomerManagedResourcesGCPRpsqlAPIServiceAccountModel arg carries forward
+// TF-only / sensitive / write-only fields and resolves the proto3
+// null-vs-empty ambiguity for Optional-only scalar leaves (Required leaves
+// flatten directly); pass nil when no prior nested state is available.
+func FlattenDataCustomerManagedResourcesGCPRpsqlAPIServiceAccount(_ context.Context, proto *controlplanev1.GCPServiceAccount, prev *DataCustomerManagedResourcesGCPRpsqlAPIServiceAccountModel) (DataCustomerManagedResourcesGCPRpsqlAPIServiceAccountModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	_ = prev
+	m := DataCustomerManagedResourcesGCPRpsqlAPIServiceAccountModel{}
+	m.Email = types.StringValue(proto.GetEmail())
+	return m, diags
+}
+
+// ExpandDataCustomerManagedResourcesGCPRpsqlAPIServiceAccount renders a nested model back into the proto type.
+func ExpandDataCustomerManagedResourcesGCPRpsqlAPIServiceAccount(_ context.Context, m *DataCustomerManagedResourcesGCPRpsqlAPIServiceAccountModel) (*controlplanev1.GCPServiceAccount, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if m == nil {
+		return nil, diags
+	}
+	out := &controlplanev1.GCPServiceAccount{
+		Email: m.Email.ValueString(),
+	}
+	return out, diags
+}
+
+// FlattenDataCustomerManagedResourcesGCPRpsqlCloudStorageBucket converts a single proto controlplanev1.CustomerManagedGoogleCloudStorageBucket into the
+// corresponding nested model. The prev *DataCustomerManagedResourcesGCPRpsqlCloudStorageBucketModel arg carries forward
+// TF-only / sensitive / write-only fields and resolves the proto3
+// null-vs-empty ambiguity for Optional-only scalar leaves (Required leaves
+// flatten directly); pass nil when no prior nested state is available.
+func FlattenDataCustomerManagedResourcesGCPRpsqlCloudStorageBucket(_ context.Context, proto *controlplanev1.CustomerManagedGoogleCloudStorageBucket, prev *DataCustomerManagedResourcesGCPRpsqlCloudStorageBucketModel) (DataCustomerManagedResourcesGCPRpsqlCloudStorageBucketModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	_ = prev
+	m := DataCustomerManagedResourcesGCPRpsqlCloudStorageBucketModel{}
+	m.Name = types.StringValue(proto.GetName())
+	return m, diags
+}
+
+// ExpandDataCustomerManagedResourcesGCPRpsqlCloudStorageBucket renders a nested model back into the proto type.
+func ExpandDataCustomerManagedResourcesGCPRpsqlCloudStorageBucket(_ context.Context, m *DataCustomerManagedResourcesGCPRpsqlCloudStorageBucketModel) (*controlplanev1.CustomerManagedGoogleCloudStorageBucket, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if m == nil {
+		return nil, diags
+	}
+	out := &controlplanev1.CustomerManagedGoogleCloudStorageBucket{
+		Name: m.Name.ValueString(),
+	}
+	return out, diags
+}
+
+// FlattenDataCustomerManagedResourcesGCPRpsqlServiceAccount converts a single proto controlplanev1.GCPServiceAccount into the
+// corresponding nested model. The prev *DataCustomerManagedResourcesGCPRpsqlServiceAccountModel arg carries forward
+// TF-only / sensitive / write-only fields and resolves the proto3
+// null-vs-empty ambiguity for Optional-only scalar leaves (Required leaves
+// flatten directly); pass nil when no prior nested state is available.
+func FlattenDataCustomerManagedResourcesGCPRpsqlServiceAccount(_ context.Context, proto *controlplanev1.GCPServiceAccount, prev *DataCustomerManagedResourcesGCPRpsqlServiceAccountModel) (DataCustomerManagedResourcesGCPRpsqlServiceAccountModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	_ = prev
+	m := DataCustomerManagedResourcesGCPRpsqlServiceAccountModel{}
+	m.Email = types.StringValue(proto.GetEmail())
+	return m, diags
+}
+
+// ExpandDataCustomerManagedResourcesGCPRpsqlServiceAccount renders a nested model back into the proto type.
+func ExpandDataCustomerManagedResourcesGCPRpsqlServiceAccount(_ context.Context, m *DataCustomerManagedResourcesGCPRpsqlServiceAccountModel) (*controlplanev1.GCPServiceAccount, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	if m == nil {
 		return nil, diags

--- a/redpanda/models/cluster/data_conv_gen.go
+++ b/redpanda/models/cluster/data_conv_gen.go
@@ -48,6 +48,7 @@ type DataClusterResponse interface {
 	GetNetworkId() string
 	GetPrometheus() *controlplanev1.Cluster_Prometheus
 	GetReadReplicaClusterIds() []string
+	GetRedpandaConnect() *controlplanev1.Cluster_RedpandaConnect
 	GetRedpandaConsole() *controlplanev1.Cluster_RedpandaConsole
 	GetRegion() string
 	GetResourceGroupId() string
@@ -123,6 +124,7 @@ func FlattenData(ctx context.Context, proto DataClusterResponse, prev *DataModel
 	m.NetworkID = types.StringValue(proto.GetNetworkId())
 	m.Prometheus = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetPrometheus(), func() *DataPrometheusModel { v, _ := prev.AsPrometheus(ctx); return v }(), DataPrometheusAttrTypes(), FlattenDataPrometheus, &diags)
 	m.ReadReplicaClusterIds = modelconv.ListFromSliceWithDiags(ctx, proto.GetReadReplicaClusterIds(), types.StringType, &diags)
+	m.RedpandaConnect = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetRedpandaConnect(), func() *DataRedpandaConnectModel { v, _ := prev.AsRedpandaConnect(ctx); return v }(), DataRedpandaConnectAttrTypes(), FlattenDataRedpandaConnect, &diags)
 	m.RedpandaConsole = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetRedpandaConsole(), func() *DataRedpandaConsoleModel { v, _ := prev.AsRedpandaConsole(ctx); return v }(), DataRedpandaConsoleAttrTypes(), FlattenDataRedpandaConsole, &diags)
 	m.Region = types.StringValue(proto.GetRegion())
 	m.ResourceGroupID = types.StringValue(proto.GetResourceGroupId())
@@ -1921,6 +1923,62 @@ func ExpandDataPrometheus(_ context.Context, m *DataPrometheusModel) (*controlpl
 	}
 	out := &controlplanev1.Cluster_Prometheus{
 		Url: m.URL.ValueString(),
+	}
+	return out, diags
+}
+
+// FlattenDataRedpandaConnect converts a single proto controlplanev1.Cluster_RedpandaConnect into the
+// corresponding nested model. The prev *DataRedpandaConnectModel arg carries forward
+// TF-only / sensitive / write-only fields and resolves the proto3
+// null-vs-empty ambiguity for Optional-only scalar leaves (Required leaves
+// flatten directly); pass nil when no prior nested state is available.
+func FlattenDataRedpandaConnect(ctx context.Context, proto *controlplanev1.Cluster_RedpandaConnect, prev *DataRedpandaConnectModel) (DataRedpandaConnectModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	_ = prev
+	m := DataRedpandaConnectModel{}
+	m.AllowedDestinationCidrPorts = modelconv.ListFromObjectsWithDiags(ctx, proto.GetAllowedDestinationCidrPorts(), DataRedpandaConnectAllowedDestinationCidrPortsAttrTypes(), FlattenDataRedpandaConnectAllowedDestinationCidrPorts, &diags)
+	m.Version = types.StringValue(proto.GetVersion())
+	return m, diags
+}
+
+// ExpandDataRedpandaConnect renders a nested model back into the proto type.
+func ExpandDataRedpandaConnect(ctx context.Context, m *DataRedpandaConnectModel) (*controlplanev1.Cluster_RedpandaConnect, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if m == nil {
+		return nil, diags
+	}
+	out := &controlplanev1.Cluster_RedpandaConnect{
+		AllowedDestinationCidrPorts: modelconv.ListToObjectsWithDiags(ctx, m.AllowedDestinationCidrPorts, ExpandDataRedpandaConnectAllowedDestinationCidrPorts, &diags),
+		Version:                     m.Version.ValueString(),
+	}
+	return out, diags
+}
+
+// FlattenDataRedpandaConnectAllowedDestinationCidrPorts converts a single proto controlplanev1.Cluster_CidrPort into the
+// corresponding nested model. The prev *DataRedpandaConnectAllowedDestinationCidrPortsModel arg carries forward
+// TF-only / sensitive / write-only fields and resolves the proto3
+// null-vs-empty ambiguity for Optional-only scalar leaves (Required leaves
+// flatten directly); pass nil when no prior nested state is available.
+func FlattenDataRedpandaConnectAllowedDestinationCidrPorts(_ context.Context, proto *controlplanev1.Cluster_CidrPort, prev *DataRedpandaConnectAllowedDestinationCidrPortsModel) (DataRedpandaConnectAllowedDestinationCidrPortsModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	_ = prev
+	m := DataRedpandaConnectAllowedDestinationCidrPortsModel{}
+	m.Cidr = types.StringValue(proto.GetCidr())
+	m.PortEnd = types.Int32Value(proto.GetPortEnd())
+	m.PortStart = types.Int32Value(proto.GetPortStart())
+	return m, diags
+}
+
+// ExpandDataRedpandaConnectAllowedDestinationCidrPorts renders a nested model back into the proto type.
+func ExpandDataRedpandaConnectAllowedDestinationCidrPorts(_ context.Context, m *DataRedpandaConnectAllowedDestinationCidrPortsModel) (*controlplanev1.Cluster_CidrPort, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if m == nil {
+		return nil, diags
+	}
+	out := &controlplanev1.Cluster_CidrPort{
+		Cidr:      m.Cidr.ValueString(),
+		PortEnd:   m.PortEnd.ValueInt32(),
+		PortStart: m.PortStart.ValueInt32(),
 	}
 	return out, diags
 }

--- a/redpanda/models/cluster/data_model_gen.go
+++ b/redpanda/models/cluster/data_model_gen.go
@@ -327,6 +327,9 @@ type DataCustomerManagedResourcesGCPModel struct {
 	GkeServiceAccount             types.Object `tfsdk:"gke_service_account"`
 	PscNatSubnetName              types.String `tfsdk:"psc_nat_subnet_name"`
 	RedpandaClusterServiceAccount types.Object `tfsdk:"redpanda_cluster_service_account"`
+	RpsqlAPIServiceAccount        types.Object `tfsdk:"rpsql_api_service_account"`
+	RpsqlCloudStorageBucket       types.Object `tfsdk:"rpsql_cloud_storage_bucket"`
+	RpsqlServiceAccount           types.Object `tfsdk:"rpsql_service_account"`
 	Subnet                        types.Object `tfsdk:"subnet"`
 	TieredStorageBucket           types.Object `tfsdk:"tiered_storage_bucket"`
 }
@@ -363,6 +366,27 @@ type DataCustomerManagedResourcesGCPGkeServiceAccountModel struct {
 // converters on the parent struct to move between types.Object and this
 // typed form.
 type DataCustomerManagedResourcesGCPRedpandaClusterServiceAccountModel struct {
+	Email types.String `tfsdk:"email"`
+}
+
+// DataCustomerManagedResourcesGCPRpsqlAPIServiceAccountModel mirrors the nested "customer_managed_resources.gcp.rpsql_api_service_account" attribute. Use the As/To
+// converters on the parent struct to move between types.Object and this
+// typed form.
+type DataCustomerManagedResourcesGCPRpsqlAPIServiceAccountModel struct {
+	Email types.String `tfsdk:"email"`
+}
+
+// DataCustomerManagedResourcesGCPRpsqlCloudStorageBucketModel mirrors the nested "customer_managed_resources.gcp.rpsql_cloud_storage_bucket" attribute. Use the As/To
+// converters on the parent struct to move between types.Object and this
+// typed form.
+type DataCustomerManagedResourcesGCPRpsqlCloudStorageBucketModel struct {
+	Name types.String `tfsdk:"name"`
+}
+
+// DataCustomerManagedResourcesGCPRpsqlServiceAccountModel mirrors the nested "customer_managed_resources.gcp.rpsql_service_account" attribute. Use the As/To
+// converters on the parent struct to move between types.Object and this
+// typed form.
+type DataCustomerManagedResourcesGCPRpsqlServiceAccountModel struct {
 	Email types.String `tfsdk:"email"`
 }
 
@@ -893,6 +917,9 @@ func DataCustomerManagedResourcesGCPAttrTypes() map[string]attr.Type {
 		"gke_service_account":              types.ObjectType{AttrTypes: DataCustomerManagedResourcesGCPGkeServiceAccountAttrTypes()},
 		"psc_nat_subnet_name":              types.StringType,
 		"redpanda_cluster_service_account": types.ObjectType{AttrTypes: DataCustomerManagedResourcesGCPRedpandaClusterServiceAccountAttrTypes()},
+		"rpsql_api_service_account":        types.ObjectType{AttrTypes: DataCustomerManagedResourcesGCPRpsqlAPIServiceAccountAttrTypes()},
+		"rpsql_cloud_storage_bucket":       types.ObjectType{AttrTypes: DataCustomerManagedResourcesGCPRpsqlCloudStorageBucketAttrTypes()},
+		"rpsql_service_account":            types.ObjectType{AttrTypes: DataCustomerManagedResourcesGCPRpsqlServiceAccountAttrTypes()},
 		"subnet":                           types.ObjectType{AttrTypes: DataCustomerManagedResourcesGCPSubnetAttrTypes()},
 		"tiered_storage_bucket":            types.ObjectType{AttrTypes: DataCustomerManagedResourcesGCPTieredStorageBucketAttrTypes()},
 	}
@@ -933,6 +960,30 @@ func DataCustomerManagedResourcesGCPGkeServiceAccountAttrTypes() map[string]attr
 // DataCustomerManagedResourcesGCPRedpandaClusterServiceAccountAttrTypes returns the attr.Type map for the "customer_managed_resources.gcp.redpanda_cluster_service_account" nested
 // attribute.
 func DataCustomerManagedResourcesGCPRedpandaClusterServiceAccountAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"email": types.StringType,
+	}
+}
+
+// DataCustomerManagedResourcesGCPRpsqlAPIServiceAccountAttrTypes returns the attr.Type map for the "customer_managed_resources.gcp.rpsql_api_service_account" nested
+// attribute.
+func DataCustomerManagedResourcesGCPRpsqlAPIServiceAccountAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"email": types.StringType,
+	}
+}
+
+// DataCustomerManagedResourcesGCPRpsqlCloudStorageBucketAttrTypes returns the attr.Type map for the "customer_managed_resources.gcp.rpsql_cloud_storage_bucket" nested
+// attribute.
+func DataCustomerManagedResourcesGCPRpsqlCloudStorageBucketAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"name": types.StringType,
+	}
+}
+
+// DataCustomerManagedResourcesGCPRpsqlServiceAccountAttrTypes returns the attr.Type map for the "customer_managed_resources.gcp.rpsql_service_account" nested
+// attribute.
+func DataCustomerManagedResourcesGCPRpsqlServiceAccountAttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
 		"email": types.StringType,
 	}
@@ -2089,6 +2140,66 @@ func DataCustomerManagedResourcesGCPRedpandaClusterServiceAccountToObject(ctx co
 		return types.ObjectNull(DataCustomerManagedResourcesGCPRedpandaClusterServiceAccountAttrTypes()), nil
 	}
 	return types.ObjectValueFrom(ctx, DataCustomerManagedResourcesGCPRedpandaClusterServiceAccountAttrTypes(), v)
+}
+
+// DecodeDataCustomerManagedResourcesGCPRpsqlAPIServiceAccount decodes the sub-field from its parent typed struct.
+// Returns (nil, nil) when the field is null or unknown.
+func DecodeDataCustomerManagedResourcesGCPRpsqlAPIServiceAccount(ctx context.Context, v *DataCustomerManagedResourcesGCPModel) (*DataCustomerManagedResourcesGCPRpsqlAPIServiceAccountModel, diag.Diagnostics) {
+	if v == nil || v.RpsqlAPIServiceAccount.IsNull() || v.RpsqlAPIServiceAccount.IsUnknown() {
+		return nil, nil
+	}
+	var out DataCustomerManagedResourcesGCPRpsqlAPIServiceAccountModel
+	d := v.RpsqlAPIServiceAccount.As(ctx, &out, basetypes.ObjectAsOptions{})
+	return &out, d
+}
+
+// DataCustomerManagedResourcesGCPRpsqlAPIServiceAccountToObject encodes a typed struct back into types.Object.
+// A nil receiver returns types.ObjectNull with the correct attribute types.
+func DataCustomerManagedResourcesGCPRpsqlAPIServiceAccountToObject(ctx context.Context, v *DataCustomerManagedResourcesGCPRpsqlAPIServiceAccountModel) (types.Object, diag.Diagnostics) {
+	if v == nil {
+		return types.ObjectNull(DataCustomerManagedResourcesGCPRpsqlAPIServiceAccountAttrTypes()), nil
+	}
+	return types.ObjectValueFrom(ctx, DataCustomerManagedResourcesGCPRpsqlAPIServiceAccountAttrTypes(), v)
+}
+
+// DecodeDataCustomerManagedResourcesGCPRpsqlCloudStorageBucket decodes the sub-field from its parent typed struct.
+// Returns (nil, nil) when the field is null or unknown.
+func DecodeDataCustomerManagedResourcesGCPRpsqlCloudStorageBucket(ctx context.Context, v *DataCustomerManagedResourcesGCPModel) (*DataCustomerManagedResourcesGCPRpsqlCloudStorageBucketModel, diag.Diagnostics) {
+	if v == nil || v.RpsqlCloudStorageBucket.IsNull() || v.RpsqlCloudStorageBucket.IsUnknown() {
+		return nil, nil
+	}
+	var out DataCustomerManagedResourcesGCPRpsqlCloudStorageBucketModel
+	d := v.RpsqlCloudStorageBucket.As(ctx, &out, basetypes.ObjectAsOptions{})
+	return &out, d
+}
+
+// DataCustomerManagedResourcesGCPRpsqlCloudStorageBucketToObject encodes a typed struct back into types.Object.
+// A nil receiver returns types.ObjectNull with the correct attribute types.
+func DataCustomerManagedResourcesGCPRpsqlCloudStorageBucketToObject(ctx context.Context, v *DataCustomerManagedResourcesGCPRpsqlCloudStorageBucketModel) (types.Object, diag.Diagnostics) {
+	if v == nil {
+		return types.ObjectNull(DataCustomerManagedResourcesGCPRpsqlCloudStorageBucketAttrTypes()), nil
+	}
+	return types.ObjectValueFrom(ctx, DataCustomerManagedResourcesGCPRpsqlCloudStorageBucketAttrTypes(), v)
+}
+
+// DecodeDataCustomerManagedResourcesGCPRpsqlServiceAccount decodes the sub-field from its parent typed struct.
+// Returns (nil, nil) when the field is null or unknown.
+func DecodeDataCustomerManagedResourcesGCPRpsqlServiceAccount(ctx context.Context, v *DataCustomerManagedResourcesGCPModel) (*DataCustomerManagedResourcesGCPRpsqlServiceAccountModel, diag.Diagnostics) {
+	if v == nil || v.RpsqlServiceAccount.IsNull() || v.RpsqlServiceAccount.IsUnknown() {
+		return nil, nil
+	}
+	var out DataCustomerManagedResourcesGCPRpsqlServiceAccountModel
+	d := v.RpsqlServiceAccount.As(ctx, &out, basetypes.ObjectAsOptions{})
+	return &out, d
+}
+
+// DataCustomerManagedResourcesGCPRpsqlServiceAccountToObject encodes a typed struct back into types.Object.
+// A nil receiver returns types.ObjectNull with the correct attribute types.
+func DataCustomerManagedResourcesGCPRpsqlServiceAccountToObject(ctx context.Context, v *DataCustomerManagedResourcesGCPRpsqlServiceAccountModel) (types.Object, diag.Diagnostics) {
+	if v == nil {
+		return types.ObjectNull(DataCustomerManagedResourcesGCPRpsqlServiceAccountAttrTypes()), nil
+	}
+	return types.ObjectValueFrom(ctx, DataCustomerManagedResourcesGCPRpsqlServiceAccountAttrTypes(), v)
 }
 
 // DecodeDataCustomerManagedResourcesGCPSubnet decodes the sub-field from its parent typed struct.

--- a/redpanda/models/cluster/data_model_gen.go
+++ b/redpanda/models/cluster/data_model_gen.go
@@ -51,6 +51,7 @@ type DataModel struct {
 	NetworkID                        types.String   `tfsdk:"network_id"`
 	Prometheus                       types.Object   `tfsdk:"prometheus"`
 	ReadReplicaClusterIds            types.List     `tfsdk:"read_replica_cluster_ids"`
+	RedpandaConnect                  types.Object   `tfsdk:"redpanda_connect"`
 	RedpandaConsole                  types.Object   `tfsdk:"redpanda_console"`
 	RedpandaVersion                  types.String   `tfsdk:"redpanda_version"`
 	Region                           types.String   `tfsdk:"region"`
@@ -571,6 +572,23 @@ type DataMaintenanceWindowConfigDayHourModel struct {
 // typed form.
 type DataPrometheusModel struct {
 	URL types.String `tfsdk:"url"`
+}
+
+// DataRedpandaConnectModel mirrors the nested "redpanda_connect" attribute. Use the As/To
+// converters on the parent struct to move between types.Object and this
+// typed form.
+type DataRedpandaConnectModel struct {
+	AllowedDestinationCidrPorts types.List   `tfsdk:"allowed_destination_cidr_ports"`
+	Version                     types.String `tfsdk:"version"`
+}
+
+// DataRedpandaConnectAllowedDestinationCidrPortsModel mirrors the nested "redpanda_connect.allowed_destination_cidr_ports" attribute. Use the As/To
+// converters on the parent struct to move between types.Object and this
+// typed form.
+type DataRedpandaConnectAllowedDestinationCidrPortsModel struct {
+	Cidr      types.String `tfsdk:"cidr"`
+	PortEnd   types.Int32  `tfsdk:"port_end"`
+	PortStart types.Int32  `tfsdk:"port_start"`
 }
 
 // DataRedpandaConsoleModel mirrors the nested "redpanda_console" attribute. Use the As/To
@@ -1193,6 +1211,25 @@ func DataPrometheusAttrTypes() map[string]attr.Type {
 	}
 }
 
+// DataRedpandaConnectAttrTypes returns the attr.Type map for the "redpanda_connect" nested
+// attribute.
+func DataRedpandaConnectAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"allowed_destination_cidr_ports": types.ListType{ElemType: types.ObjectType{AttrTypes: DataRedpandaConnectAllowedDestinationCidrPortsAttrTypes()}},
+		"version":                        types.StringType,
+	}
+}
+
+// DataRedpandaConnectAllowedDestinationCidrPortsAttrTypes returns the attr.Type map for the "redpanda_connect.allowed_destination_cidr_ports" nested
+// attribute.
+func DataRedpandaConnectAllowedDestinationCidrPortsAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"cidr":       types.StringType,
+		"port_end":   types.Int32Type,
+		"port_start": types.Int32Type,
+	}
+}
+
 // DataRedpandaConsoleAttrTypes returns the attr.Type map for the "redpanda_console" nested
 // attribute.
 func DataRedpandaConsoleAttrTypes() map[string]attr.Type {
@@ -1506,6 +1543,29 @@ func DataPrometheusToObject(ctx context.Context, v *DataPrometheusModel) (types.
 		return types.ObjectNull(DataPrometheusAttrTypes()), nil
 	}
 	return types.ObjectValueFrom(ctx, DataPrometheusAttrTypes(), v)
+}
+
+// AsRedpandaConnect converts the root redpanda_connect attribute from
+// types.Object into its typed form. Returns (nil, nil) when the object is
+// null or unknown. Use this when you want typed field access without
+// manually unpacking .Attributes().
+func (m *DataModel) AsRedpandaConnect(ctx context.Context) (*DataRedpandaConnectModel, diag.Diagnostics) {
+	if m == nil || m.RedpandaConnect.IsNull() || m.RedpandaConnect.IsUnknown() {
+		return nil, nil
+	}
+	var out DataRedpandaConnectModel
+	d := m.RedpandaConnect.As(ctx, &out, basetypes.ObjectAsOptions{})
+	return &out, d
+}
+
+// DataRedpandaConnectToObject encodes a typed struct back into the
+// types.Object shape expected by the framework. A nil receiver returns
+// types.ObjectNull with the correct attribute types.
+func DataRedpandaConnectToObject(ctx context.Context, v *DataRedpandaConnectModel) (types.Object, diag.Diagnostics) {
+	if v == nil {
+		return types.ObjectNull(DataRedpandaConnectAttrTypes()), nil
+	}
+	return types.ObjectValueFrom(ctx, DataRedpandaConnectAttrTypes(), v)
 }
 
 // AsRedpandaConsole converts the root redpanda_console attribute from

--- a/redpanda/models/cluster/resource_model_gen.go
+++ b/redpanda/models/cluster/resource_model_gen.go
@@ -57,6 +57,7 @@ type ResourceModel struct {
 	NetworkID                        types.String   `tfsdk:"network_id"`
 	Prometheus                       types.Object   `tfsdk:"prometheus"`
 	ReadReplicaClusterIds            types.List     `tfsdk:"read_replica_cluster_ids"`
+	RedpandaConnect                  types.Object   `tfsdk:"redpanda_connect"`
 	RedpandaConsole                  types.Object   `tfsdk:"redpanda_console"`
 	RedpandaNodeCount                types.Int32    `tfsdk:"redpanda_node_count"`
 	RedpandaVersion                  types.String   `tfsdk:"redpanda_version"`
@@ -244,6 +245,9 @@ type CustomerManagedResourcesGCPModel struct {
 	Subnet                        types.Object `tfsdk:"subnet"`
 	TieredStorageBucket           types.Object `tfsdk:"tiered_storage_bucket"`
 	PscNatSubnetName              types.String `tfsdk:"psc_nat_subnet_name"`
+	RpsqlAPIServiceAccount        types.Object `tfsdk:"rpsql_api_service_account"`
+	RpsqlCloudStorageBucket       types.Object `tfsdk:"rpsql_cloud_storage_bucket"`
+	RpsqlServiceAccount           types.Object `tfsdk:"rpsql_service_account"`
 }
 
 // CustomerManagedResourcesGCPAgentServiceAccountModel mirrors the nested "customer_managed_resources.gcp.agent_service_account" attribute. Use the As/To
@@ -310,6 +314,27 @@ type CustomerManagedResourcesGCPSubnetSecondaryIpv4RangeServicesModel struct {
 // typed form.
 type CustomerManagedResourcesGCPTieredStorageBucketModel struct {
 	Name types.String `tfsdk:"name"`
+}
+
+// CustomerManagedResourcesGCPRpsqlAPIServiceAccountModel mirrors the nested "customer_managed_resources.gcp.rpsql_api_service_account" attribute. Use the As/To
+// converters on the parent struct to move between types.Object and this
+// typed form.
+type CustomerManagedResourcesGCPRpsqlAPIServiceAccountModel struct {
+	Email types.String `tfsdk:"email"`
+}
+
+// CustomerManagedResourcesGCPRpsqlCloudStorageBucketModel mirrors the nested "customer_managed_resources.gcp.rpsql_cloud_storage_bucket" attribute. Use the As/To
+// converters on the parent struct to move between types.Object and this
+// typed form.
+type CustomerManagedResourcesGCPRpsqlCloudStorageBucketModel struct {
+	Name types.String `tfsdk:"name"`
+}
+
+// CustomerManagedResourcesGCPRpsqlServiceAccountModel mirrors the nested "customer_managed_resources.gcp.rpsql_service_account" attribute. Use the As/To
+// converters on the parent struct to move between types.Object and this
+// typed form.
+type CustomerManagedResourcesGCPRpsqlServiceAccountModel struct {
+	Email types.String `tfsdk:"email"`
 }
 
 // AWSPrivateLinkModel mirrors the nested "aws_private_link" attribute. Use the As/To
@@ -574,6 +599,23 @@ type MaintenanceWindowConfigDayHourModel struct {
 	HourOfDay types.Int32  `tfsdk:"hour_of_day"`
 }
 
+// RedpandaConnectModel mirrors the nested "redpanda_connect" attribute. Use the As/To
+// converters on the parent struct to move between types.Object and this
+// typed form.
+type RedpandaConnectModel struct {
+	AllowedDestinationCidrPorts types.List   `tfsdk:"allowed_destination_cidr_ports"`
+	Version                     types.String `tfsdk:"version"`
+}
+
+// RedpandaConnectAllowedDestinationCidrPortsModel mirrors the nested "redpanda_connect.allowed_destination_cidr_ports" attribute. Use the As/To
+// converters on the parent struct to move between types.Object and this
+// typed form.
+type RedpandaConnectAllowedDestinationCidrPortsModel struct {
+	Cidr      types.String `tfsdk:"cidr"`
+	PortStart types.Int32  `tfsdk:"port_start"`
+	PortEnd   types.Int32  `tfsdk:"port_end"`
+}
+
 // RpsqlModel mirrors the nested "rpsql" attribute. Use the As/To
 // converters on the parent struct to move between types.Object and this
 // typed form.
@@ -834,6 +876,9 @@ func CustomerManagedResourcesGCPAttrTypes() map[string]attr.Type {
 		"subnet":                           types.ObjectType{AttrTypes: CustomerManagedResourcesGCPSubnetAttrTypes()},
 		"tiered_storage_bucket":            types.ObjectType{AttrTypes: CustomerManagedResourcesGCPTieredStorageBucketAttrTypes()},
 		"psc_nat_subnet_name":              types.StringType,
+		"rpsql_api_service_account":        types.ObjectType{AttrTypes: CustomerManagedResourcesGCPRpsqlAPIServiceAccountAttrTypes()},
+		"rpsql_cloud_storage_bucket":       types.ObjectType{AttrTypes: CustomerManagedResourcesGCPRpsqlCloudStorageBucketAttrTypes()},
+		"rpsql_service_account":            types.ObjectType{AttrTypes: CustomerManagedResourcesGCPRpsqlServiceAccountAttrTypes()},
 	}
 }
 
@@ -909,6 +954,30 @@ func CustomerManagedResourcesGCPSubnetSecondaryIpv4RangeServicesAttrTypes() map[
 func CustomerManagedResourcesGCPTieredStorageBucketAttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
 		"name": types.StringType,
+	}
+}
+
+// CustomerManagedResourcesGCPRpsqlAPIServiceAccountAttrTypes returns the attr.Type map for the "customer_managed_resources.gcp.rpsql_api_service_account" nested
+// attribute.
+func CustomerManagedResourcesGCPRpsqlAPIServiceAccountAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"email": types.StringType,
+	}
+}
+
+// CustomerManagedResourcesGCPRpsqlCloudStorageBucketAttrTypes returns the attr.Type map for the "customer_managed_resources.gcp.rpsql_cloud_storage_bucket" nested
+// attribute.
+func CustomerManagedResourcesGCPRpsqlCloudStorageBucketAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"name": types.StringType,
+	}
+}
+
+// CustomerManagedResourcesGCPRpsqlServiceAccountAttrTypes returns the attr.Type map for the "customer_managed_resources.gcp.rpsql_service_account" nested
+// attribute.
+func CustomerManagedResourcesGCPRpsqlServiceAccountAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"email": types.StringType,
 	}
 }
 
@@ -1198,6 +1267,25 @@ func MaintenanceWindowConfigDayHourAttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
 		"day_of_week": types.StringType,
 		"hour_of_day": types.Int32Type,
+	}
+}
+
+// RedpandaConnectAttrTypes returns the attr.Type map for the "redpanda_connect" nested
+// attribute.
+func RedpandaConnectAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"allowed_destination_cidr_ports": types.ListType{ElemType: types.ObjectType{AttrTypes: RedpandaConnectAllowedDestinationCidrPortsAttrTypes()}},
+		"version":                        types.StringType,
+	}
+}
+
+// RedpandaConnectAllowedDestinationCidrPortsAttrTypes returns the attr.Type map for the "redpanda_connect.allowed_destination_cidr_ports" nested
+// attribute.
+func RedpandaConnectAllowedDestinationCidrPortsAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"cidr":       types.StringType,
+		"port_start": types.Int32Type,
+		"port_end":   types.Int32Type,
 	}
 }
 
@@ -1507,6 +1595,29 @@ func MaintenanceWindowConfigToObject(ctx context.Context, v *MaintenanceWindowCo
 		return types.ObjectNull(MaintenanceWindowConfigAttrTypes()), nil
 	}
 	return types.ObjectValueFrom(ctx, MaintenanceWindowConfigAttrTypes(), v)
+}
+
+// AsRedpandaConnect converts the root redpanda_connect attribute from
+// types.Object into its typed form. Returns (nil, nil) when the object is
+// null or unknown. Use this when you want typed field access without
+// manually unpacking .Attributes().
+func (m *ResourceModel) AsRedpandaConnect(ctx context.Context) (*RedpandaConnectModel, diag.Diagnostics) {
+	if m == nil || m.RedpandaConnect.IsNull() || m.RedpandaConnect.IsUnknown() {
+		return nil, nil
+	}
+	var out RedpandaConnectModel
+	d := m.RedpandaConnect.As(ctx, &out, basetypes.ObjectAsOptions{})
+	return &out, d
+}
+
+// RedpandaConnectToObject encodes a typed struct back into the
+// types.Object shape expected by the framework. A nil receiver returns
+// types.ObjectNull with the correct attribute types.
+func RedpandaConnectToObject(ctx context.Context, v *RedpandaConnectModel) (types.Object, diag.Diagnostics) {
+	if v == nil {
+		return types.ObjectNull(RedpandaConnectAttrTypes()), nil
+	}
+	return types.ObjectValueFrom(ctx, RedpandaConnectAttrTypes(), v)
 }
 
 // AsRpsql converts the root rpsql attribute from
@@ -2229,6 +2340,66 @@ func CustomerManagedResourcesGCPTieredStorageBucketToObject(ctx context.Context,
 	return types.ObjectValueFrom(ctx, CustomerManagedResourcesGCPTieredStorageBucketAttrTypes(), v)
 }
 
+// DecodeCustomerManagedResourcesGCPRpsqlAPIServiceAccount decodes the sub-field from its parent typed struct.
+// Returns (nil, nil) when the field is null or unknown.
+func DecodeCustomerManagedResourcesGCPRpsqlAPIServiceAccount(ctx context.Context, v *CustomerManagedResourcesGCPModel) (*CustomerManagedResourcesGCPRpsqlAPIServiceAccountModel, diag.Diagnostics) {
+	if v == nil || v.RpsqlAPIServiceAccount.IsNull() || v.RpsqlAPIServiceAccount.IsUnknown() {
+		return nil, nil
+	}
+	var out CustomerManagedResourcesGCPRpsqlAPIServiceAccountModel
+	d := v.RpsqlAPIServiceAccount.As(ctx, &out, basetypes.ObjectAsOptions{})
+	return &out, d
+}
+
+// CustomerManagedResourcesGCPRpsqlAPIServiceAccountToObject encodes a typed struct back into types.Object.
+// A nil receiver returns types.ObjectNull with the correct attribute types.
+func CustomerManagedResourcesGCPRpsqlAPIServiceAccountToObject(ctx context.Context, v *CustomerManagedResourcesGCPRpsqlAPIServiceAccountModel) (types.Object, diag.Diagnostics) {
+	if v == nil {
+		return types.ObjectNull(CustomerManagedResourcesGCPRpsqlAPIServiceAccountAttrTypes()), nil
+	}
+	return types.ObjectValueFrom(ctx, CustomerManagedResourcesGCPRpsqlAPIServiceAccountAttrTypes(), v)
+}
+
+// DecodeCustomerManagedResourcesGCPRpsqlCloudStorageBucket decodes the sub-field from its parent typed struct.
+// Returns (nil, nil) when the field is null or unknown.
+func DecodeCustomerManagedResourcesGCPRpsqlCloudStorageBucket(ctx context.Context, v *CustomerManagedResourcesGCPModel) (*CustomerManagedResourcesGCPRpsqlCloudStorageBucketModel, diag.Diagnostics) {
+	if v == nil || v.RpsqlCloudStorageBucket.IsNull() || v.RpsqlCloudStorageBucket.IsUnknown() {
+		return nil, nil
+	}
+	var out CustomerManagedResourcesGCPRpsqlCloudStorageBucketModel
+	d := v.RpsqlCloudStorageBucket.As(ctx, &out, basetypes.ObjectAsOptions{})
+	return &out, d
+}
+
+// CustomerManagedResourcesGCPRpsqlCloudStorageBucketToObject encodes a typed struct back into types.Object.
+// A nil receiver returns types.ObjectNull with the correct attribute types.
+func CustomerManagedResourcesGCPRpsqlCloudStorageBucketToObject(ctx context.Context, v *CustomerManagedResourcesGCPRpsqlCloudStorageBucketModel) (types.Object, diag.Diagnostics) {
+	if v == nil {
+		return types.ObjectNull(CustomerManagedResourcesGCPRpsqlCloudStorageBucketAttrTypes()), nil
+	}
+	return types.ObjectValueFrom(ctx, CustomerManagedResourcesGCPRpsqlCloudStorageBucketAttrTypes(), v)
+}
+
+// DecodeCustomerManagedResourcesGCPRpsqlServiceAccount decodes the sub-field from its parent typed struct.
+// Returns (nil, nil) when the field is null or unknown.
+func DecodeCustomerManagedResourcesGCPRpsqlServiceAccount(ctx context.Context, v *CustomerManagedResourcesGCPModel) (*CustomerManagedResourcesGCPRpsqlServiceAccountModel, diag.Diagnostics) {
+	if v == nil || v.RpsqlServiceAccount.IsNull() || v.RpsqlServiceAccount.IsUnknown() {
+		return nil, nil
+	}
+	var out CustomerManagedResourcesGCPRpsqlServiceAccountModel
+	d := v.RpsqlServiceAccount.As(ctx, &out, basetypes.ObjectAsOptions{})
+	return &out, d
+}
+
+// CustomerManagedResourcesGCPRpsqlServiceAccountToObject encodes a typed struct back into types.Object.
+// A nil receiver returns types.ObjectNull with the correct attribute types.
+func CustomerManagedResourcesGCPRpsqlServiceAccountToObject(ctx context.Context, v *CustomerManagedResourcesGCPRpsqlServiceAccountModel) (types.Object, diag.Diagnostics) {
+	if v == nil {
+		return types.ObjectNull(CustomerManagedResourcesGCPRpsqlServiceAccountAttrTypes()), nil
+	}
+	return types.ObjectValueFrom(ctx, CustomerManagedResourcesGCPRpsqlServiceAccountAttrTypes(), v)
+}
+
 // DecodeAWSPrivateLinkStatus decodes the sub-field from its parent typed struct.
 // Returns (nil, nil) when the field is null or unknown.
 func DecodeAWSPrivateLinkStatus(ctx context.Context, v *AWSPrivateLinkModel) (*AWSPrivateLinkStatusModel, diag.Diagnostics) {
@@ -2563,6 +2734,7 @@ func GenerateMinimalResourceModel(id types.String, timeout timeouts.Value) *Reso
 		NetworkID:                        types.StringNull(),
 		Prometheus:                       types.ObjectNull(PrometheusAttrTypes()),
 		ReadReplicaClusterIds:            types.ListNull(types.StringType),
+		RedpandaConnect:                  types.ObjectNull(RedpandaConnectAttrTypes()),
 		RedpandaConsole:                  types.ObjectNull(RedpandaConsoleAttrTypes()),
 		RedpandaNodeCount:                types.Int32Null(),
 		RedpandaVersion:                  types.StringNull(),

--- a/redpanda/resources/cluster/acc_cluster_connect_cidr_ports_test.go
+++ b/redpanda/resources/cluster/acc_cluster_connect_cidr_ports_test.go
@@ -1,0 +1,187 @@
+//go:build live_test && (all || cluster_connect_cidr_ports)
+
+// Copyright 2026 Redpanda Data, Inc.
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package cluster_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/redpanda-data/terraform-provider-redpanda/internal/testutil/acc"
+	"github.com/redpanda-data/terraform-provider-redpanda/internal/testutil/acc/sweep"
+)
+
+// TestAcc_Cluster_RedpandaConnect_CidrPorts creates a dedicated cluster with
+// allowed_destination_cidr_ports, updates the list, then clears it, verifying
+// each step round-trips the field values correctly and no cluster recreation
+// occurs (in-place update via LeafExpansion).
+func TestAcc_Cluster_RedpandaConnect_CidrPorts(t *testing.T) {
+	ctx := context.Background()
+	name := acc.RandomName(acc.NamePrefix + "rc-cidr")
+
+	resourceGroupID := os.Getenv("RESOURCE_GROUP_ID")
+	networkID := os.Getenv("NETWORK_ID")
+
+	c, err := acc.NewTestClients(ctx, acc.ClientID, acc.ClientSecret, acc.CloudEnv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	acc.Register(acc.KindCluster, acc.CleanupFunc(func(_ context.Context) error {
+		return sweep.Cluster{ClusterName: name, Client: c}.SweepCluster("")
+	}))
+	if networkID == "" {
+		acc.Register(acc.KindNetwork, acc.CleanupFunc(func(_ context.Context) error {
+			return sweep.Network{NetworkName: name, Client: c}.SweepNetworks("")
+		}))
+	}
+	if resourceGroupID == "" {
+		acc.Register(acc.KindResourceGroup, acc.CleanupFunc(func(_ context.Context) error {
+			return sweep.ResourceGroup{ResourceGroupName: name, Client: c}.SweepResourceGroup("")
+		}))
+	}
+
+	const clusterAddr = "redpanda_cluster.test"
+
+	throughputTier := "tier-1-aws-v2-x86"
+	if acc.ThroughputTier != "" {
+		throughputTier = acc.ThroughputTier
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheck(t) },
+		ProtoV6ProviderFactories: acc.ProtoV6Factories,
+		Steps: []resource.TestStep{
+			// Step 1: create cluster with two CIDR+port rules.
+			{
+				Config: cidrPortsConfig(name, throughputTier, resourceGroupID, networkID, `
+    redpanda_connect = {
+      allowed_destination_cidr_ports = [
+        { cidr = "10.0.0.0/16", port_start = 5432 },
+        { cidr = "20.0.0.0/16", port_start = 5432, port_end = 5500 },
+      ]
+    }`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(clusterAddr, "redpanda_connect.allowed_destination_cidr_ports.#", "2"),
+					resource.TestCheckResourceAttr(clusterAddr, "redpanda_connect.allowed_destination_cidr_ports.0.cidr", "10.0.0.0/16"),
+					resource.TestCheckResourceAttr(clusterAddr, "redpanda_connect.allowed_destination_cidr_ports.0.port_start", "5432"),
+					resource.TestCheckResourceAttr(clusterAddr, "redpanda_connect.allowed_destination_cidr_ports.0.port_end", "0"),
+					resource.TestCheckResourceAttr(clusterAddr, "redpanda_connect.allowed_destination_cidr_ports.1.cidr", "20.0.0.0/16"),
+					resource.TestCheckResourceAttr(clusterAddr, "redpanda_connect.allowed_destination_cidr_ports.1.port_start", "5432"),
+					resource.TestCheckResourceAttr(clusterAddr, "redpanda_connect.allowed_destination_cidr_ports.1.port_end", "5500"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+			},
+			// Step 2: remove one rule — in-place update, no cluster recreation.
+			{
+				Config: cidrPortsConfig(name, throughputTier, resourceGroupID, networkID, `
+    redpanda_connect = {
+      allowed_destination_cidr_ports = [
+        { cidr = "10.0.0.0/16", port_start = 5432 },
+      ]
+    }`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(clusterAddr, "redpanda_connect.allowed_destination_cidr_ports.#", "1"),
+					resource.TestCheckResourceAttr(clusterAddr, "redpanda_connect.allowed_destination_cidr_ports.0.cidr", "10.0.0.0/16"),
+					resource.TestCheckResourceAttr(clusterAddr, "redpanda_connect.allowed_destination_cidr_ports.0.port_start", "5432"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+			},
+			// Step 3: clear all rules.
+			{
+				Config: cidrPortsConfig(name, throughputTier, resourceGroupID, networkID, `
+    redpanda_connect = {
+      allowed_destination_cidr_ports = []
+    }`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(clusterAddr, "redpanda_connect.allowed_destination_cidr_ports.#", "0"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+			},
+			// Step 4: import — verify redpanda_connect survives state import.
+			{
+				ResourceName:            clusterAddr,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allow_deletion"},
+			},
+		},
+	})
+}
+
+// cidrPortsConfig builds the HCL config for the test. If resourceGroupID or
+// networkID are non-empty, those resources are referenced by literal ID instead
+// of being created (allowing reuse of pre-existing infra to speed up runs).
+func cidrPortsConfig(name, throughputTier, resourceGroupID, networkID, extra string) string {
+	var rgBlock, networkBlock, rgRef, networkRef string
+
+	if resourceGroupID == "" {
+		rgBlock = fmt.Sprintf(`
+resource "redpanda_resource_group" "test" {
+  name = %q
+}`, name)
+		rgRef = "redpanda_resource_group.test.id"
+	} else {
+		rgRef = fmt.Sprintf("%q", resourceGroupID)
+	}
+
+	if networkID == "" {
+		networkBlock = fmt.Sprintf(`
+resource "redpanda_network" "test" {
+  name              = %q
+  resource_group_id = %s
+  cloud_provider    = "aws"
+  region            = "us-east-2"
+  cluster_type      = "byoc"
+  cidr_block        = "10.0.0.0/20"
+  timeouts = { create = "20m", delete = "20m" }
+}`, name, rgRef)
+		networkRef = "redpanda_network.test.id"
+	} else {
+		networkRef = fmt.Sprintf("%q", networkID)
+	}
+
+	return fmt.Sprintf(`
+provider "redpanda" {}
+%s
+%s
+resource "redpanda_cluster" "test" {
+  name              = %q
+  resource_group_id = %s
+  network_id        = %s
+  cloud_provider    = "aws"
+  region            = "us-east-2"
+  zones             = ["use2-az1", "use2-az2", "use2-az3"]
+  throughput_tier   = %q
+  cluster_type      = "byoc"
+  connection_type   = "public"
+  allow_deletion    = true
+  timeouts          = { create = "90m", update = "60m" }
+%s
+}
+`, rgBlock, networkBlock, name, rgRef, networkRef, throughputTier, extra)
+}

--- a/redpanda/resources/cluster/acc_cluster_connect_cidr_ports_test.go
+++ b/redpanda/resources/cluster/acc_cluster_connect_cidr_ports_test.go
@@ -83,7 +83,7 @@ func TestAcc_Cluster_RedpandaConnect_CidrPorts(t *testing.T) {
 					resource.TestCheckResourceAttr(clusterAddr, "redpanda_connect.allowed_destination_cidr_ports.#", "2"),
 					resource.TestCheckResourceAttr(clusterAddr, "redpanda_connect.allowed_destination_cidr_ports.0.cidr", "10.0.0.0/16"),
 					resource.TestCheckResourceAttr(clusterAddr, "redpanda_connect.allowed_destination_cidr_ports.0.port_start", "5432"),
-					resource.TestCheckResourceAttr(clusterAddr, "redpanda_connect.allowed_destination_cidr_ports.0.port_end", "0"),
+					resource.TestCheckResourceAttr(clusterAddr, "redpanda_connect.allowed_destination_cidr_ports.0.port_end", "5432"),
 					resource.TestCheckResourceAttr(clusterAddr, "redpanda_connect.allowed_destination_cidr_ports.1.cidr", "20.0.0.0/16"),
 					resource.TestCheckResourceAttr(clusterAddr, "redpanda_connect.allowed_destination_cidr_ports.1.port_start", "5432"),
 					resource.TestCheckResourceAttr(clusterAddr, "redpanda_connect.allowed_destination_cidr_ports.1.port_end", "5500"),

--- a/redpanda/resources/cluster/integration_cluster_test.go
+++ b/redpanda/resources/cluster/integration_cluster_test.go
@@ -2598,3 +2598,80 @@ func TestIntegration_Cluster_NullPscNatSubnetName_Repro(t *testing.T) {
 		},
 	})
 }
+
+// TestIntegration_Cluster_UpdateLeaf_RedpandaConnect_CidrPorts exercises the
+// full create → update → clear lifecycle for
+// redpanda_connect.allowed_destination_cidr_ports. Proves that the LeafExpansion
+// for "redpanda_connect" sends the granular mask path, the fake applies the
+// update, and the provider round-trips the list through Flatten correctly.
+func TestIntegration_Cluster_UpdateLeaf_RedpandaConnect_CidrPorts(t *testing.T) {
+	_, factories := clusterSetup(t)
+
+	const name = "tfrp-mock-cl-rc-cidr"
+
+	idPreserved := statecheck.CompareValue(compare.ValuesSame())
+	cidrPath := tfjsonpath.New("redpanda_connect").AtMapKey("allowed_destination_cidr_ports")
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: factories,
+		Steps: []resource.TestStep{
+			// Create: set two CIDR+port rules.
+			integration.CreateStep(clusterAddr,
+				awsDedicatedConfig(name, `redpanda_connect = {
+    allowed_destination_cidr_ports = [
+      { cidr = "10.0.0.0/16", port_start = 5432 },
+      { cidr = "20.0.0.0/16", port_start = 5432, port_end = 5500 },
+    ]
+  }`),
+				[]statecheck.StateCheck{
+					statecheck.ExpectKnownValue(clusterAddr, cidrPath,
+						knownvalue.ListSizeExact(2)),
+					statecheck.ExpectKnownValue(clusterAddr, tfjsonpath.New("id"), knownvalue.NotNull()),
+					idPreserved.AddStateValue(clusterAddr, tfjsonpath.New("id")),
+				}),
+			// Update: remove one rule (list shrinks to 1).
+			integration.UpdateLeafStep(clusterAddr,
+				awsDedicatedConfig(name, `redpanda_connect = {
+    allowed_destination_cidr_ports = [
+      { cidr = "10.0.0.0/16", port_start = 5432 },
+    ]
+  }`),
+				[]statecheck.StateCheck{
+					statecheck.ExpectKnownValue(clusterAddr, cidrPath,
+						knownvalue.ListSizeExact(1)),
+					idPreserved.AddStateValue(clusterAddr, tfjsonpath.New("id")),
+				}),
+			// Update: clear all rules (empty list).
+			integration.UpdateLeafStep(clusterAddr,
+				awsDedicatedConfig(name, `redpanda_connect = {
+    allowed_destination_cidr_ports = []
+  }`),
+				[]statecheck.StateCheck{
+					statecheck.ExpectKnownValue(clusterAddr, cidrPath,
+						knownvalue.ListSizeExact(0)),
+					idPreserved.AddStateValue(clusterAddr, tfjsonpath.New("id")),
+				}),
+		},
+	})
+}
+
+// TestIntegration_Cluster_CidrPortInvalidRange verifies that port_end < port_start
+// is rejected at plan time by the proto-driven ConfigValidator, before any API
+// call is made. Uses UnitTest so TF_ACC is not required.
+func TestIntegration_Cluster_CidrPortInvalidRange(t *testing.T) {
+	_, factories := clusterSetup(t)
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: factories,
+		Steps: []resource.TestStep{
+			{
+				Config: awsDedicatedConfig("invalid-range", `redpanda_connect = {
+    allowed_destination_cidr_ports = [
+      { cidr = "10.0.0.0/16", port_start = 5432, port_end = 5431 },
+    ]
+  }`),
+				ExpectError: regexp.MustCompile(`port_end must be 0`),
+			},
+		},
+	})
+}

--- a/redpanda/resources/cluster/integration_cluster_test.go
+++ b/redpanda/resources/cluster/integration_cluster_test.go
@@ -2626,6 +2626,25 @@ func TestIntegration_Cluster_UpdateLeaf_RedpandaConnect_CidrPorts(t *testing.T) 
 				[]statecheck.StateCheck{
 					statecheck.ExpectKnownValue(clusterAddr, cidrPath,
 						knownvalue.ListSizeExact(2)),
+					// Verify per-entry field values round-trip correctly.
+					statecheck.ExpectKnownValue(clusterAddr,
+						cidrPath.AtSliceIndex(0).AtMapKey("cidr"),
+						knownvalue.StringExact("10.0.0.0/16")),
+					statecheck.ExpectKnownValue(clusterAddr,
+						cidrPath.AtSliceIndex(0).AtMapKey("port_start"),
+						knownvalue.Int32Exact(5432)),
+					statecheck.ExpectKnownValue(clusterAddr,
+						cidrPath.AtSliceIndex(0).AtMapKey("port_end"),
+						knownvalue.Int32Exact(0)),
+					statecheck.ExpectKnownValue(clusterAddr,
+						cidrPath.AtSliceIndex(1).AtMapKey("cidr"),
+						knownvalue.StringExact("20.0.0.0/16")),
+					statecheck.ExpectKnownValue(clusterAddr,
+						cidrPath.AtSliceIndex(1).AtMapKey("port_start"),
+						knownvalue.Int32Exact(5432)),
+					statecheck.ExpectKnownValue(clusterAddr,
+						cidrPath.AtSliceIndex(1).AtMapKey("port_end"),
+						knownvalue.Int32Exact(5500)),
 					statecheck.ExpectKnownValue(clusterAddr, tfjsonpath.New("id"), knownvalue.NotNull()),
 					idPreserved.AddStateValue(clusterAddr, tfjsonpath.New("id")),
 				}),
@@ -2639,6 +2658,12 @@ func TestIntegration_Cluster_UpdateLeaf_RedpandaConnect_CidrPorts(t *testing.T) 
 				[]statecheck.StateCheck{
 					statecheck.ExpectKnownValue(clusterAddr, cidrPath,
 						knownvalue.ListSizeExact(1)),
+					statecheck.ExpectKnownValue(clusterAddr,
+						cidrPath.AtSliceIndex(0).AtMapKey("cidr"),
+						knownvalue.StringExact("10.0.0.0/16")),
+					statecheck.ExpectKnownValue(clusterAddr,
+						cidrPath.AtSliceIndex(0).AtMapKey("port_start"),
+						knownvalue.Int32Exact(5432)),
 					idPreserved.AddStateValue(clusterAddr, tfjsonpath.New("id")),
 				}),
 			// Update: clear all rules (empty list).
@@ -2651,6 +2676,8 @@ func TestIntegration_Cluster_UpdateLeaf_RedpandaConnect_CidrPorts(t *testing.T) 
 						knownvalue.ListSizeExact(0)),
 					idPreserved.AddStateValue(clusterAddr, tfjsonpath.New("id")),
 				}),
+			// Import: verify redpanda_connect data survives an import.
+			integration.ImportRoundTripStep(clusterAddr, nil, []string{"allow_deletion"}),
 		},
 	})
 }

--- a/redpanda/resources/cluster/integration_cluster_test.go
+++ b/redpanda/resources/cluster/integration_cluster_test.go
@@ -2676,6 +2676,16 @@ func TestIntegration_Cluster_UpdateLeaf_RedpandaConnect_CidrPorts(t *testing.T) 
 						knownvalue.ListSizeExact(0)),
 					idPreserved.AddStateValue(clusterAddr, tfjsonpath.New("id")),
 				}),
+			// Noop: verify plan stabilizes at the empty state.
+			integration.NoopReapplyStep(clusterAddr,
+				awsDedicatedConfig(name, `redpanda_connect = {
+    allowed_destination_cidr_ports = []
+  }`),
+				[]statecheck.StateCheck{
+					statecheck.ExpectKnownValue(clusterAddr, cidrPath,
+						knownvalue.ListSizeExact(0)),
+					idPreserved.AddStateValue(clusterAddr, tfjsonpath.New("id")),
+				}),
 			// Import: verify redpanda_connect data survives an import.
 			integration.ImportRoundTripStep(clusterAddr, nil, []string{"allow_deletion"}),
 		},

--- a/redpanda/resources/cluster/schema.yaml
+++ b/redpanda/resources/cluster/schema.yaml
@@ -597,4 +597,21 @@ sandbox:
 
 # --- New proto fields (auto-added by schemagen -todo) ---
 redpanda_connect:
-  todo: true
+  optional: true
+  computed: true
+  plan_modifiers: [UseStateForUnknown]
+  fields:
+    version:
+      computed_only: true
+    allowed_destination_cidr_ports:
+      optional: true
+      computed: true
+      plan_modifiers: [UseStateForUnknown]
+      fields:
+        cidr:
+          required: true
+        port_start:
+          required: true
+        port_end:
+          optional: true
+          computed: true

--- a/redpanda/resources/cluster/schema.yaml
+++ b/redpanda/resources/cluster/schema.yaml
@@ -400,6 +400,8 @@ http_proxy:
   fields:
     all_urls:
       computed_only: true
+    connections:
+      todo: true
     mtls:
       fields:
         ca_certificates_pem:
@@ -423,6 +425,8 @@ kafka_api:
   fields:
     all_seed_brokers:
       computed_only: true
+    connections:
+      todo: true
     mtls:
       fields:
         ca_certificates_pem:
@@ -541,6 +545,8 @@ schema_registry:
   fields:
     all_urls:
       computed_only: true
+    connections:
+      todo: true
     mtls:
       computed: false
       optional: true

--- a/redpanda/resources/cluster/schema_datasource.yaml
+++ b/redpanda/resources/cluster/schema_datasource.yaml
@@ -122,8 +122,20 @@ cluster_configuration:
 
     computed_properties:
       todo: true
+http_proxy:
+  fields:
+    connections:
+      todo: true
+
+kafka_api:
+  fields:
+    connections:
+      todo: true
+
 schema_registry:
   fields:
+    connections:
+      todo: true
 
     sasl:
       todo: true

--- a/redpanda/resources/cluster/schema_datasource.yaml
+++ b/redpanda/resources/cluster/schema_datasource.yaml
@@ -189,4 +189,13 @@ sandbox:
 
 # --- New proto fields (auto-added by schemagen -todo) ---
 redpanda_connect:
-  todo: true
+  computed: true
+  fields:
+    version:
+      computed_only: true
+    allowed_destination_cidr_ports:
+      computed: true
+      fields:
+        cidr: {}
+        port_start: {}
+        port_end: {}

--- a/redpanda/resources/cluster/schema_datasource_gen.go
+++ b/redpanda/resources/cluster/schema_datasource_gen.go
@@ -909,6 +909,37 @@ func DatasourceClusterSchema(ctx context.Context) schema.Schema {
 				ElementType: types.StringType,
 			},
 
+			"redpanda_connect": schema.SingleNestedAttribute{
+				Description: "Cluster's Redpanda Connect properties.",
+				Computed:    true,
+				Attributes: map[string]schema.Attribute{
+					"allowed_destination_cidr_ports": schema.ListNestedAttribute{
+						Description: "List of allowed Destination CIDR Ports",
+						Computed:    true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"cidr": schema.StringAttribute{
+									Description: "CIDR",
+									Computed:    true,
+								},
+								"port_end": schema.Int32Attribute{
+									Description: "Port End",
+									Computed:    true,
+								},
+								"port_start": schema.Int32Attribute{
+									Description: "Port Start",
+									Computed:    true,
+								},
+							},
+						},
+					},
+					"version": schema.StringAttribute{
+						Description: "Version of the Redpanda Connect engine running on the Cluster.",
+						Computed:    true,
+					},
+				},
+			},
+
 			"redpanda_console": schema.SingleNestedAttribute{
 				Description: "Cluster's Redpanda Console properties.",
 				Computed:    true,

--- a/redpanda/resources/cluster/schema_datasource_gen.go
+++ b/redpanda/resources/cluster/schema_datasource_gen.go
@@ -525,6 +525,36 @@ func DatasourceClusterSchema(ctx context.Context) schema.Schema {
 									},
 								},
 							},
+							"rpsql_api_service_account": schema.SingleNestedAttribute{
+								Description: "Rpsql API Service Account configuration",
+								Computed:    true,
+								Attributes: map[string]schema.Attribute{
+									"email": schema.StringAttribute{
+										Description: "Email address for the rpsql API Service Account",
+										Computed:    true,
+									},
+								},
+							},
+							"rpsql_cloud_storage_bucket": schema.SingleNestedAttribute{
+								Description: "Rpsql Cloud Storage Bucket configuration",
+								Computed:    true,
+								Attributes: map[string]schema.Attribute{
+									"name": schema.StringAttribute{
+										Description: "Name of the rpsql Cloud Storage Bucket",
+										Computed:    true,
+									},
+								},
+							},
+							"rpsql_service_account": schema.SingleNestedAttribute{
+								Description: "Rpsql Service Account configuration",
+								Computed:    true,
+								Attributes: map[string]schema.Attribute{
+									"email": schema.StringAttribute{
+										Description: "Email address for the rpsql Service Account",
+										Computed:    true,
+									},
+								},
+							},
 							"subnet": schema.SingleNestedAttribute{
 								Description: "GCP subnet properties. See the official [GCP API reference](https://cloud.google.com/compute/docs/reference/rest/v1/subnetworks).",
 								Computed:    true,

--- a/redpanda/resources/cluster/schema_resource_gen.go
+++ b/redpanda/resources/cluster/schema_resource_gen.go
@@ -398,6 +398,42 @@ func ResourceClusterSchema(ctx context.Context) schema.Schema {
 								Optional:      true,
 								PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 							},
+							"rpsql_api_service_account": schema.SingleNestedAttribute{
+								Description:   "Rpsql API Service Account configuration",
+								Optional:      true,
+								Computed:      true,
+								PlanModifiers: []planmodifier.Object{objectplanmodifier.UseStateForUnknown()},
+								Attributes: map[string]schema.Attribute{
+									"email": schema.StringAttribute{
+										Description: "Email address for the rpsql API Service Account. Must be a valid email address.",
+										Required:    true,
+									},
+								},
+							},
+							"rpsql_cloud_storage_bucket": schema.SingleNestedAttribute{
+								Description:   "Rpsql Cloud Storage Bucket configuration",
+								Optional:      true,
+								Computed:      true,
+								PlanModifiers: []planmodifier.Object{objectplanmodifier.UseStateForUnknown()},
+								Attributes: map[string]schema.Attribute{
+									"name": schema.StringAttribute{
+										Description: "Name of the rpsql Cloud Storage Bucket. Length must be between 3 and 63. Must match pattern `^[a-z]([-_a-z0-9]*[a-z0-9])?$`.",
+										Required:    true,
+									},
+								},
+							},
+							"rpsql_service_account": schema.SingleNestedAttribute{
+								Description:   "Rpsql Service Account configuration",
+								Optional:      true,
+								Computed:      true,
+								PlanModifiers: []planmodifier.Object{objectplanmodifier.UseStateForUnknown()},
+								Attributes: map[string]schema.Attribute{
+									"email": schema.StringAttribute{
+										Description: "Email address for the rpsql Service Account. Must be a valid email address.",
+										Required:    true,
+									},
+								},
+							},
 						},
 					},
 				},
@@ -1080,6 +1116,45 @@ func ResourceClusterSchema(ctx context.Context) schema.Schema {
 						Description:   "Unspecified configuration",
 						Computed:      true,
 						PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
+					},
+				},
+			},
+
+			"redpanda_connect": schema.SingleNestedAttribute{
+				Description:   "Cluster's Redpanda Connect properties.",
+				Optional:      true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.Object{objectplanmodifier.RequiresReplace(), objectplanmodifier.UseStateForUnknown()},
+				Attributes: map[string]schema.Attribute{
+					"allowed_destination_cidr_ports": schema.ListNestedAttribute{
+						Description:   "List of allowed Destination CIDR Ports. Must have at most 16 items.",
+						Optional:      true,
+						Computed:      true,
+						PlanModifiers: []planmodifier.List{listplanmodifier.UseStateForUnknown()},
+						Validators:    []validator.List{listvalidator.SizeAtMost(16)},
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"cidr": schema.StringAttribute{
+									Description: "CIDR. Must match pattern `^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$`.",
+									Required:    true,
+								},
+								"port_start": schema.Int32Attribute{
+									Description: "Port Start. Must be between 1 and 65535 (inclusive).",
+									Required:    true,
+								},
+								"port_end": schema.Int32Attribute{
+									Description:   "Port End. Must be at most 65535.",
+									Optional:      true,
+									Computed:      true,
+									PlanModifiers: []planmodifier.Int32{int32planmodifier.UseStateForUnknown()},
+								},
+							},
+						},
+					},
+					"version": schema.StringAttribute{
+						Description:   "Version of the Redpanda Connect engine running on the Cluster.",
+						Computed:      true,
+						PlanModifiers: []planmodifier.String{stringplanmodifier.UseNonNullStateForUnknown()},
 					},
 				},
 			},

--- a/redpanda/resources/cluster/schema_resource_gen.go
+++ b/redpanda/resources/cluster/schema_resource_gen.go
@@ -1124,7 +1124,7 @@ func ResourceClusterSchema(ctx context.Context) schema.Schema {
 				Description:   "Cluster's Redpanda Connect properties.",
 				Optional:      true,
 				Computed:      true,
-				PlanModifiers: []planmodifier.Object{objectplanmodifier.RequiresReplace(), objectplanmodifier.UseStateForUnknown()},
+				PlanModifiers: []planmodifier.Object{objectplanmodifier.UseStateForUnknown()},
 				Attributes: map[string]schema.Attribute{
 					"allowed_destination_cidr_ports": schema.ListNestedAttribute{
 						Description:   "List of allowed Destination CIDR Ports. Must have at most 16 items.",

--- a/redpanda/resources/cluster/validators_cidr_port_test.go
+++ b/redpanda/resources/cluster/validators_cidr_port_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package cluster
+
+import (
+	"strings"
+	"testing"
+
+	controlplanev1 "buf.build/gen/go/redpandadata/cloud/protocolbuffers/go/redpanda/api/controlplane/v1"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	rpvalidate "github.com/redpanda-data/terraform-provider-redpanda/redpanda/utils/protovalidate"
+)
+
+// TestCidrPortPortEndProtoValidation proves that the buf.validate CEL
+// constraint on Cluster_CidrPort —
+//
+//	this.port_end == 0 || this.port_end >= this.port_start
+//
+// is enforced by rpvalidate.Validate (the same function the protoValidator
+// calls at plan time). No separate attribute-level validator is needed
+// because ConfigValidators already covers this constraint.
+func TestCidrPortPortEndProtoValidation(t *testing.T) {
+	cases := []struct {
+		name      string
+		portStart int32
+		portEnd   int32
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:      "single port (portEnd=0)",
+			portStart: 5432,
+			portEnd:   0,
+			wantErr:   false,
+		},
+		{
+			name:      "valid range",
+			portStart: 5432,
+			portEnd:   5500,
+			wantErr:   false,
+		},
+		{
+			name:      "same start and end",
+			portStart: 5432,
+			portEnd:   5432,
+			wantErr:   false,
+		},
+		{
+			name:      "portEnd < portStart",
+			portStart: 5432,
+			portEnd:   5431,
+			wantErr:   true,
+			errSubstr: "port_end",
+		},
+		{
+			name:      "portEnd < portStart large gap",
+			portStart: 1000,
+			portEnd:   999,
+			wantErr:   true,
+			errSubstr: "port_end",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := &controlplanev1.Cluster_CidrPort{
+				Cidr:      "10.0.0.0/8",
+				PortStart: tc.portStart,
+				PortEnd:   tc.portEnd,
+			}
+			diags := rpvalidate.Validate(path.Empty(), msg)
+			if tc.wantErr && !diags.HasError() {
+				t.Errorf("expected validation error for portStart=%d portEnd=%d, got none",
+					tc.portStart, tc.portEnd)
+			}
+			if !tc.wantErr && diags.HasError() {
+				t.Errorf("expected no error for portStart=%d portEnd=%d, got: %v",
+					tc.portStart, tc.portEnd, diags)
+			}
+			if tc.wantErr && tc.errSubstr != "" {
+				found := false
+				for _, d := range diags {
+					if strings.Contains(d.Summary(), tc.errSubstr) ||
+						strings.Contains(d.Detail(), tc.errSubstr) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected diagnostic containing %q; got: %v", tc.errSubstr, diags)
+				}
+			}
+		})
+	}
+}

--- a/redpanda/resources/testdata/cluster_datasource_schema.golden
+++ b/redpanda/resources/testdata/cluster_datasource_schema.golden
@@ -345,6 +345,27 @@ attributes:
                 - name: email
                   type: StringAttribute
                   computed: true
+            - name: rpsql_api_service_account
+              type: SingleNestedAttribute
+              computed: true
+              attributes:
+                - name: email
+                  type: StringAttribute
+                  computed: true
+            - name: rpsql_cloud_storage_bucket
+              type: SingleNestedAttribute
+              computed: true
+              attributes:
+                - name: name
+                  type: StringAttribute
+                  computed: true
+            - name: rpsql_service_account
+              type: SingleNestedAttribute
+              computed: true
+              attributes:
+                - name: email
+                  type: StringAttribute
+                  computed: true
             - name: subnet
               type: SingleNestedAttribute
               computed: true

--- a/redpanda/resources/testdata/cluster_datasource_schema.golden
+++ b/redpanda/resources/testdata/cluster_datasource_schema.golden
@@ -610,6 +610,26 @@ attributes:
       type: ListAttribute
       computed: true
       element_type: basetypes.StringType
+    - name: redpanda_connect
+      type: SingleNestedAttribute
+      computed: true
+      attributes:
+        - name: allowed_destination_cidr_ports
+          type: ListNestedAttribute
+          computed: true
+          attributes:
+            - name: cidr
+              type: StringAttribute
+              computed: true
+            - name: port_end
+              type: Int32Attribute
+              computed: true
+            - name: port_start
+              type: Int32Attribute
+              computed: true
+        - name: version
+          type: StringAttribute
+          computed: true
     - name: redpanda_console
       type: SingleNestedAttribute
       computed: true

--- a/redpanda/resources/testdata/cluster_resource_schema.golden
+++ b/redpanda/resources/testdata/cluster_resource_schema.golden
@@ -961,7 +961,6 @@ attributes:
       optional: true
       computed: true
       plan_modifiers:
-        - objectplanmodifier.requiresReplaceIfModifier
         - objectplanmodifier.useStateForUnknownModifier
       attributes:
         - name: allowed_destination_cidr_ports

--- a/redpanda/resources/testdata/cluster_resource_schema.golden
+++ b/redpanda/resources/testdata/cluster_resource_schema.golden
@@ -541,6 +541,36 @@ attributes:
                   required: true
                   plan_modifiers:
                     - stringplanmodifier.requiresReplaceIfModifier
+            - name: rpsql_api_service_account
+              type: SingleNestedAttribute
+              optional: true
+              computed: true
+              plan_modifiers:
+                - objectplanmodifier.useStateForUnknownModifier
+              attributes:
+                - name: email
+                  type: StringAttribute
+                  required: true
+            - name: rpsql_cloud_storage_bucket
+              type: SingleNestedAttribute
+              optional: true
+              computed: true
+              plan_modifiers:
+                - objectplanmodifier.useStateForUnknownModifier
+              attributes:
+                - name: name
+                  type: StringAttribute
+                  required: true
+            - name: rpsql_service_account
+              type: SingleNestedAttribute
+              optional: true
+              computed: true
+              plan_modifiers:
+                - objectplanmodifier.useStateForUnknownModifier
+              attributes:
+                - name: email
+                  type: StringAttribute
+                  required: true
             - name: subnet
               type: SingleNestedAttribute
               required: true
@@ -926,6 +956,40 @@ attributes:
         - listvalidator.sizeAtMostValidator
         - listvalidator.uniqueValuesValidator
       element_type: basetypes.StringType
+    - name: redpanda_connect
+      type: SingleNestedAttribute
+      optional: true
+      computed: true
+      plan_modifiers:
+        - objectplanmodifier.requiresReplaceIfModifier
+        - objectplanmodifier.useStateForUnknownModifier
+      attributes:
+        - name: allowed_destination_cidr_ports
+          type: ListNestedAttribute
+          optional: true
+          computed: true
+          validators:
+            - listvalidator.sizeAtMostValidator
+          plan_modifiers:
+            - listplanmodifier.useStateForUnknownModifier
+          attributes:
+            - name: cidr
+              type: StringAttribute
+              required: true
+            - name: port_end
+              type: Int32Attribute
+              optional: true
+              computed: true
+              plan_modifiers:
+                - int32planmodifier.useStateForUnknownModifier
+            - name: port_start
+              type: Int32Attribute
+              required: true
+        - name: version
+          type: StringAttribute
+          computed: true
+          plan_modifiers:
+            - stringplanmodifier.useNonNullStateForUnknown
     - name: redpanda_console
       type: SingleNestedAttribute
       computed: true


### PR DESCRIPTION
## Summary

- Exposes `redpanda_connect.allowed_destination_cidr_ports` on the `redpanda_cluster` resource and data source, letting users configure up to 16 CIDR+port-range rules for Connect outbound traffic
- Updates are **in-place** (no cluster recreation) via the existing `redpanda_connect.allowed_destination_cidr_ports` field-mask leaf path
- `port_end = 0` means single-port rule; `port_end > 0` must be `>= port_start` — enforced at plan time by protovalidate

## Changes

- `go.mod`: bump `buf.build/gen/go/redpandadata/cloud/protocolbuffers/go` for `Cluster_CidrPort` / `Cluster_RedpandaConnect` types (cloudv2 PR #27262)
- `redpanda/resources/cluster/schema.yaml`: replace `redpanda_connect: todo: true` with full field definition
- `redpanda/resources/cluster/schema_datasource.yaml`: expose `redpanda_connect` as computed-only on data source
- `internal/clustermask/paths.go`: add `redpanda_connect` to `LeafExpansions` (path: `redpanda_connect.allowed_destination_cidr_ports`)
- `internal/schemagen/flatten_expand_plan.go`: add `ListCarryKnownEmpty` for `AttrTypeListNested` optional fields (prevents "inconsistent result after apply" when clearing the list)
- `fakes/cluster.go`: mock updated to echo back `redpanda_connect` data
- All `*_gen.go` files regenerated via `task generate:models`

## Example usage

```hcl
resource "redpanda_cluster" "example" {
  # ... other config ...

  redpanda_connect = {
    allowed_destination_cidr_ports = [
      { cidr = "10.0.0.0/16", port_start = 5432 },
      { cidr = "20.0.0.0/16", port_start = 5432, port_end = 5500 },
    ]
  }
}
```

## Test plan

- [x] `task test:unit` passes (all 63 packages)
- [x] Unit test: `TestCidrPortPortEndProtoValidation` — 5 cases covering port range constraint
- [x] Integration test: `TestIntegration_Cluster_UpdateLeaf_RedpandaConnect_CidrPorts` — create → update → clear lifecycle with field-value assertions, import round-trip, and no-op reapply step
- [x] Integration test: `TestIntegration_Cluster_CidrPortInvalidRange` — plan-time rejection of `port_end < port_start`
- [ ] Acceptance test (`TF_ACC=1`): requires a live cluster — to be run before merge

## Related

- cloudv2 PR #27262: `feat(connect): allow customers to specify custom outbound CIDR+port destinations for Connect pipelines`

🤖 Generated with [Claude Code](https://claude.com/claude-code)