### PR TITLE
feat(cluster): add GCP RPSQL fields to customer_managed_resources

### DIFF
--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -354,6 +354,7 @@ Read-Only:
 - `redpanda_cluster_service_account` (Attributes) GCP service account. (see [below for nested schema](#nestedatt--customer_managed_resources--gcp--redpanda_cluster_service_account))
 - `rpsql_api_service_account` (Attributes) GCP service account. (see [below for nested schema](#nestedatt--customer_managed_resources--gcp--rpsql_api_service_account))
 - `rpsql_cloud_storage_bucket` (Attributes) GCP storage bucket properties. (see [below for nested schema](#nestedatt--customer_managed_resources--gcp--rpsql_cloud_storage_bucket))
+- `rpsql_secret_manager_prefix` (String) GCP Secret Manager prefix for Redpanda SQL Iceberg catalog credentials. Required when configuring an Iceberg catalog on a BYOVPC cluster. The prefix should be a resource path of the form "projects/PROJECT/secrets/PREFIX" where the rpsql API service account has been granted access to all secrets under that prefix.
 - `rpsql_service_account` (Attributes) GCP service account. (see [below for nested schema](#nestedatt--customer_managed_resources--gcp--rpsql_service_account))
 - `subnet` (Attributes) GCP subnet properties. See the official [GCP API reference](https://cloud.google.com/compute/docs/reference/rest/v1/subnetworks). (see [below for nested schema](#nestedatt--customer_managed_resources--gcp--subnet))
 - `tiered_storage_bucket` (Attributes) GCP storage bucket properties. (see [below for nested schema](#nestedatt--customer_managed_resources--gcp--tiered_storage_bucket))

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -408,6 +408,7 @@ Optional:
 - `psc_nat_subnet_name` (String) NAT subnet name if GCP Private Service Connect (a.k.a Private Link) is enabled. If it is used for PSC v1, use psc_v2_nat_subnet_name to set NAT subnet name for PSC v2.
 - `rpsql_api_service_account` (Attributes) GCP service account. (see [below for nested schema](#nestedatt--customer_managed_resources--gcp--rpsql_api_service_account))
 - `rpsql_cloud_storage_bucket` (Attributes) GCP storage bucket properties. (see [below for nested schema](#nestedatt--customer_managed_resources--gcp--rpsql_cloud_storage_bucket))
+- `rpsql_secret_manager_prefix` (String) GCP Secret Manager prefix for Redpanda SQL Iceberg catalog credentials. Required when configuring an Iceberg catalog on a BYOVPC cluster. The prefix should be a resource path of the form "projects/PROJECT/secrets/PREFIX" where the rpsql API service account has been granted access to all secrets under that prefix.
 - `rpsql_service_account` (Attributes) GCP service account. (see [below for nested schema](#nestedatt--customer_managed_resources--gcp--rpsql_service_account))
 
 <a id="nestedatt--customer_managed_resources--gcp--agent_service_account"></a>

--- a/redpanda/models/cluster/conv_gen.go
+++ b/redpanda/models/cluster/conv_gen.go
@@ -940,6 +940,13 @@ func FlattenCustomerManagedResourcesGCP(ctx context.Context, proto *controlplane
 		v, _ := DecodeCustomerManagedResourcesGCPRpsqlCloudStorageBucket(ctx, prev)
 		return v
 	}(), CustomerManagedResourcesGCPRpsqlCloudStorageBucketAttrTypes(), FlattenCustomerManagedResourcesGCPRpsqlCloudStorageBucket, &diags)
+	if v := proto.GetRpsqlSecretManagerPrefix(); v != "" {
+		m.RpsqlSecretManagerPrefix = types.StringValue(v)
+	} else if prev != nil && !prev.RpsqlSecretManagerPrefix.IsUnknown() {
+		m.RpsqlSecretManagerPrefix = prev.RpsqlSecretManagerPrefix
+	} else {
+		m.RpsqlSecretManagerPrefix = types.StringNull()
+	}
 	m.RpsqlServiceAccount = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetRpsqlServiceAccount(), func() *CustomerManagedResourcesGCPRpsqlServiceAccountModel {
 		v, _ := DecodeCustomerManagedResourcesGCPRpsqlServiceAccount(ctx, prev)
 		return v
@@ -964,6 +971,7 @@ func ExpandCustomerManagedResourcesGCP(ctx context.Context, m *CustomerManagedRe
 		PscNatSubnetName:              m.PscNatSubnetName.ValueString(),
 		RpsqlApiServiceAccount:        modelconv.ObjectToMessageWithDiags(ctx, m.RpsqlAPIServiceAccount, ExpandCustomerManagedResourcesGCPRpsqlAPIServiceAccount, &diags),
 		RpsqlCloudStorageBucket:       modelconv.ObjectToMessageWithDiags(ctx, m.RpsqlCloudStorageBucket, ExpandCustomerManagedResourcesGCPRpsqlCloudStorageBucket, &diags),
+		RpsqlSecretManagerPrefix:      m.RpsqlSecretManagerPrefix.ValueString(),
 		RpsqlServiceAccount:           modelconv.ObjectToMessageWithDiags(ctx, m.RpsqlServiceAccount, ExpandCustomerManagedResourcesGCPRpsqlServiceAccount, &diags),
 	}
 	return out, diags
@@ -2767,10 +2775,11 @@ func ExpandUpdateCustomerManagedResourcesGCP(ctx context.Context, m *CustomerMan
 		return nil, diags
 	}
 	out := &controlplanev1.CustomerManagedResourcesUpdate_GCP{
-		PscNatSubnetName:        m.PscNatSubnetName.ValueString(),
-		RpsqlApiServiceAccount:  modelconv.ObjectToMessageWithDiags(ctx, m.RpsqlAPIServiceAccount, ExpandUpdateCustomerManagedResourcesGCPRpsqlAPIServiceAccount, &diags),
-		RpsqlCloudStorageBucket: modelconv.ObjectToMessageWithDiags(ctx, m.RpsqlCloudStorageBucket, ExpandUpdateCustomerManagedResourcesGCPRpsqlCloudStorageBucket, &diags),
-		RpsqlServiceAccount:     modelconv.ObjectToMessageWithDiags(ctx, m.RpsqlServiceAccount, ExpandUpdateCustomerManagedResourcesGCPRpsqlServiceAccount, &diags),
+		PscNatSubnetName:         m.PscNatSubnetName.ValueString(),
+		RpsqlApiServiceAccount:   modelconv.ObjectToMessageWithDiags(ctx, m.RpsqlAPIServiceAccount, ExpandUpdateCustomerManagedResourcesGCPRpsqlAPIServiceAccount, &diags),
+		RpsqlCloudStorageBucket:  modelconv.ObjectToMessageWithDiags(ctx, m.RpsqlCloudStorageBucket, ExpandUpdateCustomerManagedResourcesGCPRpsqlCloudStorageBucket, &diags),
+		RpsqlSecretManagerPrefix: m.RpsqlSecretManagerPrefix.ValueString(),
+		RpsqlServiceAccount:      modelconv.ObjectToMessageWithDiags(ctx, m.RpsqlServiceAccount, ExpandUpdateCustomerManagedResourcesGCPRpsqlServiceAccount, &diags),
 	}
 	return out, diags
 }

--- a/redpanda/models/cluster/data_conv_gen.go
+++ b/redpanda/models/cluster/data_conv_gen.go
@@ -1076,6 +1076,7 @@ func FlattenDataCustomerManagedResourcesGCP(ctx context.Context, proto *controlp
 		v, _ := DecodeDataCustomerManagedResourcesGCPRpsqlCloudStorageBucket(ctx, prev)
 		return v
 	}(), DataCustomerManagedResourcesGCPRpsqlCloudStorageBucketAttrTypes(), FlattenDataCustomerManagedResourcesGCPRpsqlCloudStorageBucket, &diags)
+	m.RpsqlSecretManagerPrefix = types.StringValue(proto.GetRpsqlSecretManagerPrefix())
 	m.RpsqlServiceAccount = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetRpsqlServiceAccount(), func() *DataCustomerManagedResourcesGCPRpsqlServiceAccountModel {
 		v, _ := DecodeDataCustomerManagedResourcesGCPRpsqlServiceAccount(ctx, prev)
 		return v
@@ -1106,6 +1107,7 @@ func ExpandDataCustomerManagedResourcesGCP(ctx context.Context, m *DataCustomerM
 		RedpandaClusterServiceAccount: modelconv.ObjectToMessageWithDiags(ctx, m.RedpandaClusterServiceAccount, ExpandDataCustomerManagedResourcesGCPRedpandaClusterServiceAccount, &diags),
 		RpsqlApiServiceAccount:        modelconv.ObjectToMessageWithDiags(ctx, m.RpsqlAPIServiceAccount, ExpandDataCustomerManagedResourcesGCPRpsqlAPIServiceAccount, &diags),
 		RpsqlCloudStorageBucket:       modelconv.ObjectToMessageWithDiags(ctx, m.RpsqlCloudStorageBucket, ExpandDataCustomerManagedResourcesGCPRpsqlCloudStorageBucket, &diags),
+		RpsqlSecretManagerPrefix:      m.RpsqlSecretManagerPrefix.ValueString(),
 		RpsqlServiceAccount:           modelconv.ObjectToMessageWithDiags(ctx, m.RpsqlServiceAccount, ExpandDataCustomerManagedResourcesGCPRpsqlServiceAccount, &diags),
 		Subnet:                        modelconv.ObjectToMessageWithDiags(ctx, m.Subnet, ExpandDataCustomerManagedResourcesGCPSubnet, &diags),
 		TieredStorageBucket:           modelconv.ObjectToMessageWithDiags(ctx, m.TieredStorageBucket, ExpandDataCustomerManagedResourcesGCPTieredStorageBucket, &diags),

--- a/redpanda/models/cluster/data_model_gen.go
+++ b/redpanda/models/cluster/data_model_gen.go
@@ -330,6 +330,7 @@ type DataCustomerManagedResourcesGCPModel struct {
 	RedpandaClusterServiceAccount types.Object `tfsdk:"redpanda_cluster_service_account"`
 	RpsqlAPIServiceAccount        types.Object `tfsdk:"rpsql_api_service_account"`
 	RpsqlCloudStorageBucket       types.Object `tfsdk:"rpsql_cloud_storage_bucket"`
+	RpsqlSecretManagerPrefix      types.String `tfsdk:"rpsql_secret_manager_prefix"`
 	RpsqlServiceAccount           types.Object `tfsdk:"rpsql_service_account"`
 	Subnet                        types.Object `tfsdk:"subnet"`
 	TieredStorageBucket           types.Object `tfsdk:"tiered_storage_bucket"`
@@ -937,6 +938,7 @@ func DataCustomerManagedResourcesGCPAttrTypes() map[string]attr.Type {
 		"redpanda_cluster_service_account": types.ObjectType{AttrTypes: DataCustomerManagedResourcesGCPRedpandaClusterServiceAccountAttrTypes()},
 		"rpsql_api_service_account":        types.ObjectType{AttrTypes: DataCustomerManagedResourcesGCPRpsqlAPIServiceAccountAttrTypes()},
 		"rpsql_cloud_storage_bucket":       types.ObjectType{AttrTypes: DataCustomerManagedResourcesGCPRpsqlCloudStorageBucketAttrTypes()},
+		"rpsql_secret_manager_prefix":      types.StringType,
 		"rpsql_service_account":            types.ObjectType{AttrTypes: DataCustomerManagedResourcesGCPRpsqlServiceAccountAttrTypes()},
 		"subnet":                           types.ObjectType{AttrTypes: DataCustomerManagedResourcesGCPSubnetAttrTypes()},
 		"tiered_storage_bucket":            types.ObjectType{AttrTypes: DataCustomerManagedResourcesGCPTieredStorageBucketAttrTypes()},

--- a/redpanda/models/cluster/resource_model_gen.go
+++ b/redpanda/models/cluster/resource_model_gen.go
@@ -247,6 +247,7 @@ type CustomerManagedResourcesGCPModel struct {
 	PscNatSubnetName              types.String `tfsdk:"psc_nat_subnet_name"`
 	RpsqlAPIServiceAccount        types.Object `tfsdk:"rpsql_api_service_account"`
 	RpsqlCloudStorageBucket       types.Object `tfsdk:"rpsql_cloud_storage_bucket"`
+	RpsqlSecretManagerPrefix      types.String `tfsdk:"rpsql_secret_manager_prefix"`
 	RpsqlServiceAccount           types.Object `tfsdk:"rpsql_service_account"`
 }
 
@@ -878,6 +879,7 @@ func CustomerManagedResourcesGCPAttrTypes() map[string]attr.Type {
 		"psc_nat_subnet_name":              types.StringType,
 		"rpsql_api_service_account":        types.ObjectType{AttrTypes: CustomerManagedResourcesGCPRpsqlAPIServiceAccountAttrTypes()},
 		"rpsql_cloud_storage_bucket":       types.ObjectType{AttrTypes: CustomerManagedResourcesGCPRpsqlCloudStorageBucketAttrTypes()},
+		"rpsql_secret_manager_prefix":      types.StringType,
 		"rpsql_service_account":            types.ObjectType{AttrTypes: CustomerManagedResourcesGCPRpsqlServiceAccountAttrTypes()},
 	}
 }

--- a/redpanda/resources/cluster/integration_cluster_test.go
+++ b/redpanda/resources/cluster/integration_cluster_test.go
@@ -377,7 +377,11 @@ resource "redpanda_cluster" "test" {
         secondary_ipv4_range_pods     = { name = "pods-range" }
         secondary_ipv4_range_services = { name = "svc-range" }
       }
-      tiered_storage_bucket = { name = "tfrp-tiered-bucket" }%s
+      tiered_storage_bucket       = { name = "tfrp-tiered-bucket" }
+      rpsql_api_service_account   = { email = "rpsql-api@tfrp-proj.iam.gserviceaccount.com" }
+      rpsql_service_account       = { email = "rpsql@tfrp-proj.iam.gserviceaccount.com" }
+      rpsql_cloud_storage_bucket  = { name = "tfrp-rpsql-storage" }
+      rpsql_secret_manager_prefix = "tfrp-rpsql-"%s
     }
   }
 }
@@ -774,6 +778,18 @@ func TestIntegration_Cluster_CreateAndRefresh_GCP_BYOVPC(t *testing.T) {
 				statecheck.ExpectKnownValue(clusterAddr,
 					tfjsonpath.New("customer_managed_resources").AtMapKey("gcp").AtMapKey("tiered_storage_bucket").AtMapKey("name"),
 					knownvalue.StringExact("tfrp-tiered-bucket")),
+				statecheck.ExpectKnownValue(clusterAddr,
+					tfjsonpath.New("customer_managed_resources").AtMapKey("gcp").AtMapKey("rpsql_api_service_account").AtMapKey("email"),
+					knownvalue.StringExact("rpsql-api@tfrp-proj.iam.gserviceaccount.com")),
+				statecheck.ExpectKnownValue(clusterAddr,
+					tfjsonpath.New("customer_managed_resources").AtMapKey("gcp").AtMapKey("rpsql_service_account").AtMapKey("email"),
+					knownvalue.StringExact("rpsql@tfrp-proj.iam.gserviceaccount.com")),
+				statecheck.ExpectKnownValue(clusterAddr,
+					tfjsonpath.New("customer_managed_resources").AtMapKey("gcp").AtMapKey("rpsql_cloud_storage_bucket").AtMapKey("name"),
+					knownvalue.StringExact("tfrp-rpsql-storage")),
+				statecheck.ExpectKnownValue(clusterAddr,
+					tfjsonpath.New("customer_managed_resources").AtMapKey("gcp").AtMapKey("rpsql_secret_manager_prefix"),
+					knownvalue.StringExact("tfrp-rpsql-")),
 				statecheck.ExpectKnownValue(clusterAddr, tfjsonpath.New("id"), knownvalue.NotNull()),
 				statecheck.ExpectKnownValue(clusterAddr, tfjsonpath.New("state"), knownvalue.StringExact("STATE_READY")),
 				idPreserved.AddStateValue(clusterAddr, tfjsonpath.New("id")),

--- a/redpanda/resources/cluster/schema.yaml
+++ b/redpanda/resources/cluster/schema.yaml
@@ -323,7 +323,6 @@ customer_managed_resources:
         rpsql_secret_manager_prefix:
           computed: false
           optional: true
-          plan_modifiers: [RequiresReplace]
         rpsql_service_account:
           computed: false
           optional: true

--- a/redpanda/resources/cluster/schema.yaml
+++ b/redpanda/resources/cluster/schema.yaml
@@ -320,6 +320,10 @@ customer_managed_resources:
             name:
               plan_modifiers: [RequiresReplace]
               required: true
+        rpsql_secret_manager_prefix:
+          computed: false
+          optional: true
+          plan_modifiers: [RequiresReplace]
         rpsql_service_account:
           computed: false
           optional: true
@@ -362,8 +366,6 @@ customer_managed_resources:
         redpanda_connect_service_account:
           todo: true
         redpanda_operator_service_account:
-          todo: true
-        rpsql_secret_manager_prefix:
           todo: true
     azure:
       todo: true

--- a/redpanda/resources/cluster/schema_datasource.yaml
+++ b/redpanda/resources/cluster/schema_datasource.yaml
@@ -99,8 +99,6 @@ customer_managed_resources:
           todo: true
         redpanda_operator_service_account:
           todo: true
-        rpsql_secret_manager_prefix:
-          todo: true
     aws:
       fields:
         rpsql_node_group_instance_profile:

--- a/redpanda/resources/cluster/schema_datasource_gen.go
+++ b/redpanda/resources/cluster/schema_datasource_gen.go
@@ -545,6 +545,10 @@ func DatasourceClusterSchema(ctx context.Context) schema.Schema {
 									},
 								},
 							},
+							"rpsql_secret_manager_prefix": schema.StringAttribute{
+								Description: "GCP Secret Manager prefix for Redpanda SQL Iceberg catalog credentials. Required when configuring an Iceberg catalog on a BYOVPC cluster. The prefix should be a resource path of the form \"projects/PROJECT/secrets/PREFIX\" where the rpsql API service account has been granted access to all secrets under that prefix.",
+								Computed:    true,
+							},
 							"rpsql_service_account": schema.SingleNestedAttribute{
 								Description: "GCP service account.",
 								Computed:    true,

--- a/redpanda/resources/cluster/schema_resource_gen.go
+++ b/redpanda/resources/cluster/schema_resource_gen.go
@@ -422,9 +422,8 @@ func ResourceClusterSchema(ctx context.Context) schema.Schema {
 								},
 							},
 							"rpsql_secret_manager_prefix": schema.StringAttribute{
-								Description:   "GCP Secret Manager prefix for Redpanda SQL Iceberg catalog credentials. Required when configuring an Iceberg catalog on a BYOVPC cluster. The prefix should be a resource path of the form \"projects/PROJECT/secrets/PREFIX\" where the rpsql API service account has been granted access to all secrets under that prefix.",
-								Optional:      true,
-								PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+								Description: "GCP Secret Manager prefix for Redpanda SQL Iceberg catalog credentials. Required when configuring an Iceberg catalog on a BYOVPC cluster. The prefix should be a resource path of the form \"projects/PROJECT/secrets/PREFIX\" where the rpsql API service account has been granted access to all secrets under that prefix.",
+								Optional:    true,
 							},
 							"rpsql_service_account": schema.SingleNestedAttribute{
 								Description: "GCP service account.",

--- a/redpanda/resources/cluster/schema_resource_gen.go
+++ b/redpanda/resources/cluster/schema_resource_gen.go
@@ -421,6 +421,11 @@ func ResourceClusterSchema(ctx context.Context) schema.Schema {
 									},
 								},
 							},
+							"rpsql_secret_manager_prefix": schema.StringAttribute{
+								Description:   "GCP Secret Manager prefix for Redpanda SQL Iceberg catalog credentials. Required when configuring an Iceberg catalog on a BYOVPC cluster. The prefix should be a resource path of the form \"projects/PROJECT/secrets/PREFIX\" where the rpsql API service account has been granted access to all secrets under that prefix.",
+								Optional:      true,
+								PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+							},
 							"rpsql_service_account": schema.SingleNestedAttribute{
 								Description: "GCP service account.",
 								Optional:    true,

--- a/redpanda/resources/testdata/cluster_datasource_schema.golden
+++ b/redpanda/resources/testdata/cluster_datasource_schema.golden
@@ -359,6 +359,9 @@ attributes:
                 - name: name
                   type: StringAttribute
                   computed: true
+            - name: rpsql_secret_manager_prefix
+              type: StringAttribute
+              computed: true
             - name: rpsql_service_account
               type: SingleNestedAttribute
               computed: true

--- a/redpanda/resources/testdata/cluster_resource_schema.golden
+++ b/redpanda/resources/testdata/cluster_resource_schema.golden
@@ -562,8 +562,6 @@ attributes:
             - name: rpsql_secret_manager_prefix
               type: StringAttribute
               optional: true
-              plan_modifiers:
-                - stringplanmodifier.requiresReplaceIfModifier
             - name: rpsql_service_account
               type: SingleNestedAttribute
               optional: true

--- a/redpanda/resources/testdata/cluster_resource_schema.golden
+++ b/redpanda/resources/testdata/cluster_resource_schema.golden
@@ -559,6 +559,11 @@ attributes:
                   required: true
                   plan_modifiers:
                     - stringplanmodifier.requiresReplaceIfModifier
+            - name: rpsql_secret_manager_prefix
+              type: StringAttribute
+              optional: true
+              plan_modifiers:
+                - stringplanmodifier.requiresReplaceIfModifier
             - name: rpsql_service_account
               type: SingleNestedAttribute
               optional: true


### PR DESCRIPTION
## Summary
- Adds `rpsql_api_service_account`, `rpsql_service_account`, `rpsql_cloud_storage_bucket`, and `rpsql_secret_manager_prefix` to `customer_managed_resources.gcp` on `redpanda_cluster`, mirroring the existing AWS `rpsql_*` block shape. These back the GCP BYOVPC Redpanda SQL infrastructure in `terraform-gcp-redpanda-byovpc`.
- Extends the existing `TestIntegration_Cluster_CreateAndRefresh_GCP_BYOVPC` test (via the shared `gcpBYOVPCConfig` helper) rather than adding a new test function.
- Bumps `internal/buf_dependencies.yaml` (cloudv2/console pins) so schemagen can see the new proto fields, and bumps the `buf.build/redpandadata/cloud` generated Go package to match.

Note: the `serverlesscluster` / `quota` diff riding along in the generated-files commit is unrelated upstream drift picked up by the same deps-pin bump, not new work from this PR — happy to split it into a separate PR if preferred.

## Test plan
- [x] `task test:unit`
- [x] `task test:integration`
- [x] `go test ./redpanda/resources/ -run TestSchemaGolden`
- [x] `task lint`
- [x] `task docs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)