### PR TITLE
Update redpanda terraform provider to support TGW gateway

### DIFF
--- a/docs/data-sources/network.md
+++ b/docs/data-sources/network.md
@@ -104,8 +104,16 @@ Required:
 
 Read-Only:
 
-<<<<<<< HEAD
+- `aws` (Attributes) AWS configuration (see [below for nested schema](#nestedatt--egress_spec--aws))
 - `azure` (Attributes) Azure configuration (see [below for nested schema](#nestedatt--egress_spec--azure))
+
+<a id="nestedatt--egress_spec--aws"></a>
+### Nested Schema for `egress_spec.aws`
+
+Read-Only:
+
+- `transit_gateway_id` (String) Transit Gateway ID
+
 
 <a id="nestedatt--egress_spec--azure"></a>
 ### Nested Schema for `egress_spec.azure`
@@ -114,16 +122,6 @@ Read-Only:
 
 - `firewall_private_ip` (String) Firewall Private Ip
 - `hub_vnet_id` (String) Hub Vnet ID
-=======
-- `aws` (Attributes) AWS configuration (see [below for nested schema](#nestedatt--egress_spec--aws))
-
-<a id="nestedatt--egress_spec--aws"></a>
-### Nested Schema for `egress_spec.aws`
-
-Read-Only:
-
-- `transit_gateway_id` (String) Transit Gateway ID
->>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
 
 ## Usage
 

--- a/docs/data-sources/network.md
+++ b/docs/data-sources/network.md
@@ -104,6 +104,7 @@ Required:
 
 Read-Only:
 
+<<<<<<< HEAD
 - `azure` (Attributes) Azure configuration (see [below for nested schema](#nestedatt--egress_spec--azure))
 
 <a id="nestedatt--egress_spec--azure"></a>
@@ -113,6 +114,16 @@ Read-Only:
 
 - `firewall_private_ip` (String) Firewall Private Ip
 - `hub_vnet_id` (String) Hub Vnet ID
+=======
+- `aws` (Attributes) AWS configuration (see [below for nested schema](#nestedatt--egress_spec--aws))
+
+<a id="nestedatt--egress_spec--aws"></a>
+### Nested Schema for `egress_spec.aws`
+
+Read-Only:
+
+- `transit_gateway_id` (String) Transit Gateway ID
+>>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
 
 ## Usage
 

--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -110,6 +110,7 @@ Required:
 
 Optional:
 
+<<<<<<< HEAD
 - `azure` (Attributes) Azure configuration (see [below for nested schema](#nestedatt--egress_spec--azure))
 
 <a id="nestedatt--egress_spec--azure"></a>
@@ -119,6 +120,16 @@ Required:
 
 - `firewall_private_ip` (String) Firewall Private Ip. Must be a valid IP address.
 - `hub_vnet_id` (String) Hub Vnet ID. Length must be at least 1.
+=======
+- `aws` (Attributes) AWS configuration (see [below for nested schema](#nestedatt--egress_spec--aws))
+
+<a id="nestedatt--egress_spec--aws"></a>
+### Nested Schema for `egress_spec.aws`
+
+Required:
+
+- `transit_gateway_id` (String) Transit Gateway ID. Must match pattern `^tgw-[0-9a-f]{8,}$`.
+>>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
 
 
 

--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -110,8 +110,16 @@ Required:
 
 Optional:
 
-<<<<<<< HEAD
+- `aws` (Attributes) AWS configuration (see [below for nested schema](#nestedatt--egress_spec--aws))
 - `azure` (Attributes) Azure configuration (see [below for nested schema](#nestedatt--egress_spec--azure))
+
+<a id="nestedatt--egress_spec--aws"></a>
+### Nested Schema for `egress_spec.aws`
+
+Required:
+
+- `transit_gateway_id` (String) Transit Gateway ID. Must match pattern `^tgw-[0-9a-f]{8,}$`.
+
 
 <a id="nestedatt--egress_spec--azure"></a>
 ### Nested Schema for `egress_spec.azure`
@@ -120,16 +128,6 @@ Required:
 
 - `firewall_private_ip` (String) Firewall Private Ip. Must be a valid IP address.
 - `hub_vnet_id` (String) Hub Vnet ID. Length must be at least 1.
-=======
-- `aws` (Attributes) AWS configuration (see [below for nested schema](#nestedatt--egress_spec--aws))
-
-<a id="nestedatt--egress_spec--aws"></a>
-### Nested Schema for `egress_spec.aws`
-
-Required:
-
-- `transit_gateway_id` (String) Transit Gateway ID. Must match pattern `^tgw-[0-9a-f]{8,}$`.
->>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
 
 
 

--- a/internal/schemagen/validators.go
+++ b/internal/schemagen/validators.go
@@ -169,6 +169,14 @@ var validatorRegistry = map[string]ValidatorDef{
 		},
 		AttrType: "String",
 	},
+	"TransitGatewayID": {
+		Expr: "stringvalidator.RegexMatches(\n\t\t\t\t\tregexp.MustCompile(`^tgw-[0-9a-f]{8,}$`),\n\t\t\t\t\t\"must be a valid AWS Transit Gateway ID (e.g., tgw-0123456789abcdef0)\",\n\t\t\t\t)",
+		Imports: []string{
+			"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator",
+			"regexp",
+		},
+		AttrType: "String",
+	},
 	"LengthAtMost": {
 		Parameterized: true,
 		GenFunc: func(_ string, params map[string]string) (string, []string) {

--- a/redpanda/models/network/conv_gen.go
+++ b/redpanda/models/network/conv_gen.go
@@ -339,7 +339,11 @@ func FlattenEgressSpec(ctx context.Context, proto *controlplanev1.Network_Egress
 	var diags diag.Diagnostics
 	_ = prev
 	m := EgressSpecModel{}
+<<<<<<< HEAD
 	m.Azure = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetAzure(), func() *EgressSpecAzureModel { v, _ := DecodeEgressSpecAzure(ctx, prev); return v }(), EgressSpecAzureAttrTypes(), FlattenEgressSpecAzure, &diags)
+=======
+	m.AWS = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetAws(), func() *EgressSpecAWSModel { v, _ := DecodeEgressSpecAWS(ctx, prev); return v }(), EgressSpecAWSAttrTypes(), FlattenEgressSpecAWS, &diags)
+>>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
 	return m, diags
 }
 
@@ -350,12 +354,18 @@ func ExpandEgressSpec(ctx context.Context, m *EgressSpecModel) (*controlplanev1.
 		return nil, diags
 	}
 	out := &controlplanev1.Network_EgressSpec{}
+<<<<<<< HEAD
 	if v := modelconv.ObjectToMessageWithDiags(ctx, m.Azure, ExpandEgressSpecAzure, &diags); v != nil {
 		out.SetAzure(v)
+=======
+	if v := modelconv.ObjectToMessageWithDiags(ctx, m.AWS, ExpandEgressSpecAWS, &diags); v != nil {
+		out.SetAws(v)
+>>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
 	}
 	return out, diags
 }
 
+<<<<<<< HEAD
 // FlattenEgressSpecAzure converts a single proto controlplanev1.Network_EgressSpec_Azure into the
 // corresponding nested model. The prev *EgressSpecAzureModel arg carries forward
 // TF-only / sensitive / write-only fields and resolves the proto3
@@ -372,13 +382,35 @@ func FlattenEgressSpecAzure(_ context.Context, proto *controlplanev1.Network_Egr
 
 // ExpandEgressSpecAzure renders a nested model back into the proto type.
 func ExpandEgressSpecAzure(_ context.Context, m *EgressSpecAzureModel) (*controlplanev1.Network_EgressSpec_Azure, diag.Diagnostics) {
+=======
+// FlattenEgressSpecAWS converts a single proto controlplanev1.Network_EgressSpec_AWS into the
+// corresponding nested model. The prev *EgressSpecAWSModel arg carries forward
+// TF-only / sensitive / write-only fields and resolves the proto3
+// null-vs-empty ambiguity for Optional-only scalar leaves (Required leaves
+// flatten directly); pass nil when no prior nested state is available.
+func FlattenEgressSpecAWS(_ context.Context, proto *controlplanev1.Network_EgressSpec_AWS, prev *EgressSpecAWSModel) (EgressSpecAWSModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	_ = prev
+	m := EgressSpecAWSModel{}
+	m.TransitGatewayID = types.StringValue(proto.GetTransitGatewayId())
+	return m, diags
+}
+
+// ExpandEgressSpecAWS renders a nested model back into the proto type.
+func ExpandEgressSpecAWS(_ context.Context, m *EgressSpecAWSModel) (*controlplanev1.Network_EgressSpec_AWS, diag.Diagnostics) {
+>>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
 	var diags diag.Diagnostics
 	if m == nil {
 		return nil, diags
 	}
+<<<<<<< HEAD
 	out := &controlplanev1.Network_EgressSpec_Azure{
 		FirewallPrivateIp: m.FirewallPrivateIp.ValueString(),
 		HubVnetId:         m.HubVnetID.ValueString(),
+=======
+	out := &controlplanev1.Network_EgressSpec_AWS{
+		TransitGatewayId: m.TransitGatewayID.ValueString(),
+>>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
 	}
 	return out, diags
 }

--- a/redpanda/models/network/conv_gen.go
+++ b/redpanda/models/network/conv_gen.go
@@ -339,11 +339,8 @@ func FlattenEgressSpec(ctx context.Context, proto *controlplanev1.Network_Egress
 	var diags diag.Diagnostics
 	_ = prev
 	m := EgressSpecModel{}
-<<<<<<< HEAD
-	m.Azure = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetAzure(), func() *EgressSpecAzureModel { v, _ := DecodeEgressSpecAzure(ctx, prev); return v }(), EgressSpecAzureAttrTypes(), FlattenEgressSpecAzure, &diags)
-=======
 	m.AWS = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetAws(), func() *EgressSpecAWSModel { v, _ := DecodeEgressSpecAWS(ctx, prev); return v }(), EgressSpecAWSAttrTypes(), FlattenEgressSpecAWS, &diags)
->>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
+	m.Azure = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetAzure(), func() *EgressSpecAzureModel { v, _ := DecodeEgressSpecAzure(ctx, prev); return v }(), EgressSpecAzureAttrTypes(), FlattenEgressSpecAzure, &diags)
 	return m, diags
 }
 
@@ -354,18 +351,40 @@ func ExpandEgressSpec(ctx context.Context, m *EgressSpecModel) (*controlplanev1.
 		return nil, diags
 	}
 	out := &controlplanev1.Network_EgressSpec{}
-<<<<<<< HEAD
-	if v := modelconv.ObjectToMessageWithDiags(ctx, m.Azure, ExpandEgressSpecAzure, &diags); v != nil {
-		out.SetAzure(v)
-=======
 	if v := modelconv.ObjectToMessageWithDiags(ctx, m.AWS, ExpandEgressSpecAWS, &diags); v != nil {
 		out.SetAws(v)
->>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
+	}
+	if v := modelconv.ObjectToMessageWithDiags(ctx, m.Azure, ExpandEgressSpecAzure, &diags); v != nil {
+		out.SetAzure(v)
 	}
 	return out, diags
 }
 
-<<<<<<< HEAD
+// FlattenEgressSpecAWS converts a single proto controlplanev1.Network_EgressSpec_AWS into the
+// corresponding nested model. The prev *EgressSpecAWSModel arg carries forward
+// TF-only / sensitive / write-only fields and resolves the proto3
+// null-vs-empty ambiguity for Optional-only scalar leaves (Required leaves
+// flatten directly); pass nil when no prior nested state is available.
+func FlattenEgressSpecAWS(_ context.Context, proto *controlplanev1.Network_EgressSpec_AWS, prev *EgressSpecAWSModel) (EgressSpecAWSModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	_ = prev
+	m := EgressSpecAWSModel{}
+	m.TransitGatewayID = types.StringValue(proto.GetTransitGatewayId())
+	return m, diags
+}
+
+// ExpandEgressSpecAWS renders a nested model back into the proto type.
+func ExpandEgressSpecAWS(_ context.Context, m *EgressSpecAWSModel) (*controlplanev1.Network_EgressSpec_AWS, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if m == nil {
+		return nil, diags
+	}
+	out := &controlplanev1.Network_EgressSpec_AWS{
+		TransitGatewayId: m.TransitGatewayID.ValueString(),
+	}
+	return out, diags
+}
+
 // FlattenEgressSpecAzure converts a single proto controlplanev1.Network_EgressSpec_Azure into the
 // corresponding nested model. The prev *EgressSpecAzureModel arg carries forward
 // TF-only / sensitive / write-only fields and resolves the proto3
@@ -382,35 +401,13 @@ func FlattenEgressSpecAzure(_ context.Context, proto *controlplanev1.Network_Egr
 
 // ExpandEgressSpecAzure renders a nested model back into the proto type.
 func ExpandEgressSpecAzure(_ context.Context, m *EgressSpecAzureModel) (*controlplanev1.Network_EgressSpec_Azure, diag.Diagnostics) {
-=======
-// FlattenEgressSpecAWS converts a single proto controlplanev1.Network_EgressSpec_AWS into the
-// corresponding nested model. The prev *EgressSpecAWSModel arg carries forward
-// TF-only / sensitive / write-only fields and resolves the proto3
-// null-vs-empty ambiguity for Optional-only scalar leaves (Required leaves
-// flatten directly); pass nil when no prior nested state is available.
-func FlattenEgressSpecAWS(_ context.Context, proto *controlplanev1.Network_EgressSpec_AWS, prev *EgressSpecAWSModel) (EgressSpecAWSModel, diag.Diagnostics) {
-	var diags diag.Diagnostics
-	_ = prev
-	m := EgressSpecAWSModel{}
-	m.TransitGatewayID = types.StringValue(proto.GetTransitGatewayId())
-	return m, diags
-}
-
-// ExpandEgressSpecAWS renders a nested model back into the proto type.
-func ExpandEgressSpecAWS(_ context.Context, m *EgressSpecAWSModel) (*controlplanev1.Network_EgressSpec_AWS, diag.Diagnostics) {
->>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
 	var diags diag.Diagnostics
 	if m == nil {
 		return nil, diags
 	}
-<<<<<<< HEAD
 	out := &controlplanev1.Network_EgressSpec_Azure{
 		FirewallPrivateIp: m.FirewallPrivateIp.ValueString(),
 		HubVnetId:         m.HubVnetID.ValueString(),
-=======
-	out := &controlplanev1.Network_EgressSpec_AWS{
-		TransitGatewayId: m.TransitGatewayID.ValueString(),
->>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
 	}
 	return out, diags
 }

--- a/redpanda/models/network/data_conv_gen.go
+++ b/redpanda/models/network/data_conv_gen.go
@@ -306,11 +306,8 @@ func FlattenDataEgressSpec(ctx context.Context, proto *controlplanev1.Network_Eg
 	var diags diag.Diagnostics
 	_ = prev
 	m := DataEgressSpecModel{}
-<<<<<<< HEAD
-	m.Azure = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetAzure(), func() *DataEgressSpecAzureModel { v, _ := DecodeDataEgressSpecAzure(ctx, prev); return v }(), DataEgressSpecAzureAttrTypes(), FlattenDataEgressSpecAzure, &diags)
-=======
 	m.AWS = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetAws(), func() *DataEgressSpecAWSModel { v, _ := DecodeDataEgressSpecAWS(ctx, prev); return v }(), DataEgressSpecAWSAttrTypes(), FlattenDataEgressSpecAWS, &diags)
->>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
+	m.Azure = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetAzure(), func() *DataEgressSpecAzureModel { v, _ := DecodeDataEgressSpecAzure(ctx, prev); return v }(), DataEgressSpecAzureAttrTypes(), FlattenDataEgressSpecAzure, &diags)
 	return m, diags
 }
 
@@ -321,18 +318,40 @@ func ExpandDataEgressSpec(ctx context.Context, m *DataEgressSpecModel) (*control
 		return nil, diags
 	}
 	out := &controlplanev1.Network_EgressSpec{}
-<<<<<<< HEAD
-	if v := modelconv.ObjectToMessageWithDiags(ctx, m.Azure, ExpandDataEgressSpecAzure, &diags); v != nil {
-		out.SetAzure(v)
-=======
 	if v := modelconv.ObjectToMessageWithDiags(ctx, m.AWS, ExpandDataEgressSpecAWS, &diags); v != nil {
 		out.SetAws(v)
->>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
+	}
+	if v := modelconv.ObjectToMessageWithDiags(ctx, m.Azure, ExpandDataEgressSpecAzure, &diags); v != nil {
+		out.SetAzure(v)
 	}
 	return out, diags
 }
 
-<<<<<<< HEAD
+// FlattenDataEgressSpecAWS converts a single proto controlplanev1.Network_EgressSpec_AWS into the
+// corresponding nested model. The prev *DataEgressSpecAWSModel arg carries forward
+// TF-only / sensitive / write-only fields and resolves the proto3
+// null-vs-empty ambiguity for Optional-only scalar leaves (Required leaves
+// flatten directly); pass nil when no prior nested state is available.
+func FlattenDataEgressSpecAWS(_ context.Context, proto *controlplanev1.Network_EgressSpec_AWS, prev *DataEgressSpecAWSModel) (DataEgressSpecAWSModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	_ = prev
+	m := DataEgressSpecAWSModel{}
+	m.TransitGatewayID = types.StringValue(proto.GetTransitGatewayId())
+	return m, diags
+}
+
+// ExpandDataEgressSpecAWS renders a nested model back into the proto type.
+func ExpandDataEgressSpecAWS(_ context.Context, m *DataEgressSpecAWSModel) (*controlplanev1.Network_EgressSpec_AWS, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if m == nil {
+		return nil, diags
+	}
+	out := &controlplanev1.Network_EgressSpec_AWS{
+		TransitGatewayId: m.TransitGatewayID.ValueString(),
+	}
+	return out, diags
+}
+
 // FlattenDataEgressSpecAzure converts a single proto controlplanev1.Network_EgressSpec_Azure into the
 // corresponding nested model. The prev *DataEgressSpecAzureModel arg carries forward
 // TF-only / sensitive / write-only fields and resolves the proto3
@@ -349,35 +368,13 @@ func FlattenDataEgressSpecAzure(_ context.Context, proto *controlplanev1.Network
 
 // ExpandDataEgressSpecAzure renders a nested model back into the proto type.
 func ExpandDataEgressSpecAzure(_ context.Context, m *DataEgressSpecAzureModel) (*controlplanev1.Network_EgressSpec_Azure, diag.Diagnostics) {
-=======
-// FlattenDataEgressSpecAWS converts a single proto controlplanev1.Network_EgressSpec_AWS into the
-// corresponding nested model. The prev *DataEgressSpecAWSModel arg carries forward
-// TF-only / sensitive / write-only fields and resolves the proto3
-// null-vs-empty ambiguity for Optional-only scalar leaves (Required leaves
-// flatten directly); pass nil when no prior nested state is available.
-func FlattenDataEgressSpecAWS(_ context.Context, proto *controlplanev1.Network_EgressSpec_AWS, prev *DataEgressSpecAWSModel) (DataEgressSpecAWSModel, diag.Diagnostics) {
-	var diags diag.Diagnostics
-	_ = prev
-	m := DataEgressSpecAWSModel{}
-	m.TransitGatewayID = types.StringValue(proto.GetTransitGatewayId())
-	return m, diags
-}
-
-// ExpandDataEgressSpecAWS renders a nested model back into the proto type.
-func ExpandDataEgressSpecAWS(_ context.Context, m *DataEgressSpecAWSModel) (*controlplanev1.Network_EgressSpec_AWS, diag.Diagnostics) {
->>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
 	var diags diag.Diagnostics
 	if m == nil {
 		return nil, diags
 	}
-<<<<<<< HEAD
 	out := &controlplanev1.Network_EgressSpec_Azure{
 		FirewallPrivateIp: m.FirewallPrivateIp.ValueString(),
 		HubVnetId:         m.HubVnetID.ValueString(),
-=======
-	out := &controlplanev1.Network_EgressSpec_AWS{
-		TransitGatewayId: m.TransitGatewayID.ValueString(),
->>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
 	}
 	return out, diags
 }

--- a/redpanda/models/network/data_conv_gen.go
+++ b/redpanda/models/network/data_conv_gen.go
@@ -306,7 +306,11 @@ func FlattenDataEgressSpec(ctx context.Context, proto *controlplanev1.Network_Eg
 	var diags diag.Diagnostics
 	_ = prev
 	m := DataEgressSpecModel{}
+<<<<<<< HEAD
 	m.Azure = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetAzure(), func() *DataEgressSpecAzureModel { v, _ := DecodeDataEgressSpecAzure(ctx, prev); return v }(), DataEgressSpecAzureAttrTypes(), FlattenDataEgressSpecAzure, &diags)
+=======
+	m.AWS = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetAws(), func() *DataEgressSpecAWSModel { v, _ := DecodeDataEgressSpecAWS(ctx, prev); return v }(), DataEgressSpecAWSAttrTypes(), FlattenDataEgressSpecAWS, &diags)
+>>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
 	return m, diags
 }
 
@@ -317,12 +321,18 @@ func ExpandDataEgressSpec(ctx context.Context, m *DataEgressSpecModel) (*control
 		return nil, diags
 	}
 	out := &controlplanev1.Network_EgressSpec{}
+<<<<<<< HEAD
 	if v := modelconv.ObjectToMessageWithDiags(ctx, m.Azure, ExpandDataEgressSpecAzure, &diags); v != nil {
 		out.SetAzure(v)
+=======
+	if v := modelconv.ObjectToMessageWithDiags(ctx, m.AWS, ExpandDataEgressSpecAWS, &diags); v != nil {
+		out.SetAws(v)
+>>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
 	}
 	return out, diags
 }
 
+<<<<<<< HEAD
 // FlattenDataEgressSpecAzure converts a single proto controlplanev1.Network_EgressSpec_Azure into the
 // corresponding nested model. The prev *DataEgressSpecAzureModel arg carries forward
 // TF-only / sensitive / write-only fields and resolves the proto3
@@ -339,13 +349,35 @@ func FlattenDataEgressSpecAzure(_ context.Context, proto *controlplanev1.Network
 
 // ExpandDataEgressSpecAzure renders a nested model back into the proto type.
 func ExpandDataEgressSpecAzure(_ context.Context, m *DataEgressSpecAzureModel) (*controlplanev1.Network_EgressSpec_Azure, diag.Diagnostics) {
+=======
+// FlattenDataEgressSpecAWS converts a single proto controlplanev1.Network_EgressSpec_AWS into the
+// corresponding nested model. The prev *DataEgressSpecAWSModel arg carries forward
+// TF-only / sensitive / write-only fields and resolves the proto3
+// null-vs-empty ambiguity for Optional-only scalar leaves (Required leaves
+// flatten directly); pass nil when no prior nested state is available.
+func FlattenDataEgressSpecAWS(_ context.Context, proto *controlplanev1.Network_EgressSpec_AWS, prev *DataEgressSpecAWSModel) (DataEgressSpecAWSModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	_ = prev
+	m := DataEgressSpecAWSModel{}
+	m.TransitGatewayID = types.StringValue(proto.GetTransitGatewayId())
+	return m, diags
+}
+
+// ExpandDataEgressSpecAWS renders a nested model back into the proto type.
+func ExpandDataEgressSpecAWS(_ context.Context, m *DataEgressSpecAWSModel) (*controlplanev1.Network_EgressSpec_AWS, diag.Diagnostics) {
+>>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
 	var diags diag.Diagnostics
 	if m == nil {
 		return nil, diags
 	}
+<<<<<<< HEAD
 	out := &controlplanev1.Network_EgressSpec_Azure{
 		FirewallPrivateIp: m.FirewallPrivateIp.ValueString(),
 		HubVnetId:         m.HubVnetID.ValueString(),
+=======
+	out := &controlplanev1.Network_EgressSpec_AWS{
+		TransitGatewayId: m.TransitGatewayID.ValueString(),
+>>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
 	}
 	return out, diags
 }

--- a/redpanda/models/network/data_model_gen.go
+++ b/redpanda/models/network/data_model_gen.go
@@ -109,8 +109,15 @@ type DataCustomerManagedResourcesGCPManagementBucketModel struct {
 // converters on the parent struct to move between types.Object and this
 // typed form.
 type DataEgressSpecModel struct {
-<<<<<<< HEAD
+	AWS   types.Object `tfsdk:"aws"`
 	Azure types.Object `tfsdk:"azure"`
+}
+
+// DataEgressSpecAWSModel mirrors the nested "egress_spec.aws" attribute. Use the As/To
+// converters on the parent struct to move between types.Object and this
+// typed form.
+type DataEgressSpecAWSModel struct {
+	TransitGatewayID types.String `tfsdk:"transit_gateway_id"`
 }
 
 // DataEgressSpecAzureModel mirrors the nested "egress_spec.azure" attribute. Use the As/To
@@ -119,16 +126,6 @@ type DataEgressSpecModel struct {
 type DataEgressSpecAzureModel struct {
 	FirewallPrivateIp types.String `tfsdk:"firewall_private_ip"`
 	HubVnetID         types.String `tfsdk:"hub_vnet_id"`
-=======
-	AWS types.Object `tfsdk:"aws"`
-}
-
-// DataEgressSpecAWSModel mirrors the nested "egress_spec.aws" attribute. Use the As/To
-// converters on the parent struct to move between types.Object and this
-// typed form.
-type DataEgressSpecAWSModel struct {
-	TransitGatewayID types.String `tfsdk:"transit_gateway_id"`
->>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
 }
 
 // --- AttrType tables for nested types (consumed by types.ObjectValueFrom / ObjectNull) ---
@@ -207,8 +204,16 @@ func DataCustomerManagedResourcesGCPManagementBucketAttrTypes() map[string]attr.
 // attribute.
 func DataEgressSpecAttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
-<<<<<<< HEAD
+		"aws":   types.ObjectType{AttrTypes: DataEgressSpecAWSAttrTypes()},
 		"azure": types.ObjectType{AttrTypes: DataEgressSpecAzureAttrTypes()},
+	}
+}
+
+// DataEgressSpecAWSAttrTypes returns the attr.Type map for the "egress_spec.aws" nested
+// attribute.
+func DataEgressSpecAWSAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"transit_gateway_id": types.StringType,
 	}
 }
 
@@ -218,17 +223,6 @@ func DataEgressSpecAzureAttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
 		"firewall_private_ip": types.StringType,
 		"hub_vnet_id":         types.StringType,
-=======
-		"aws": types.ObjectType{AttrTypes: DataEgressSpecAWSAttrTypes()},
-	}
-}
-
-// DataEgressSpecAWSAttrTypes returns the attr.Type map for the "egress_spec.aws" nested
-// attribute.
-func DataEgressSpecAWSAttrTypes() map[string]attr.Type {
-	return map[string]attr.Type{
-		"transit_gateway_id": types.StringType,
->>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
 	}
 }
 
@@ -422,26 +416,6 @@ func DataCustomerManagedResourcesGCPManagementBucketToObject(ctx context.Context
 	return types.ObjectValueFrom(ctx, DataCustomerManagedResourcesGCPManagementBucketAttrTypes(), v)
 }
 
-<<<<<<< HEAD
-// DecodeDataEgressSpecAzure decodes the sub-field from its parent typed struct.
-// Returns (nil, nil) when the field is null or unknown.
-func DecodeDataEgressSpecAzure(ctx context.Context, v *DataEgressSpecModel) (*DataEgressSpecAzureModel, diag.Diagnostics) {
-	if v == nil || v.Azure.IsNull() || v.Azure.IsUnknown() {
-		return nil, nil
-	}
-	var out DataEgressSpecAzureModel
-	d := v.Azure.As(ctx, &out, basetypes.ObjectAsOptions{})
-	return &out, d
-}
-
-// DataEgressSpecAzureToObject encodes a typed struct back into types.Object.
-// A nil receiver returns types.ObjectNull with the correct attribute types.
-func DataEgressSpecAzureToObject(ctx context.Context, v *DataEgressSpecAzureModel) (types.Object, diag.Diagnostics) {
-	if v == nil {
-		return types.ObjectNull(DataEgressSpecAzureAttrTypes()), nil
-	}
-	return types.ObjectValueFrom(ctx, DataEgressSpecAzureAttrTypes(), v)
-=======
 // DecodeDataEgressSpecAWS decodes the sub-field from its parent typed struct.
 // Returns (nil, nil) when the field is null or unknown.
 func DecodeDataEgressSpecAWS(ctx context.Context, v *DataEgressSpecModel) (*DataEgressSpecAWSModel, diag.Diagnostics) {
@@ -460,5 +434,24 @@ func DataEgressSpecAWSToObject(ctx context.Context, v *DataEgressSpecAWSModel) (
 		return types.ObjectNull(DataEgressSpecAWSAttrTypes()), nil
 	}
 	return types.ObjectValueFrom(ctx, DataEgressSpecAWSAttrTypes(), v)
->>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
+}
+
+// DecodeDataEgressSpecAzure decodes the sub-field from its parent typed struct.
+// Returns (nil, nil) when the field is null or unknown.
+func DecodeDataEgressSpecAzure(ctx context.Context, v *DataEgressSpecModel) (*DataEgressSpecAzureModel, diag.Diagnostics) {
+	if v == nil || v.Azure.IsNull() || v.Azure.IsUnknown() {
+		return nil, nil
+	}
+	var out DataEgressSpecAzureModel
+	d := v.Azure.As(ctx, &out, basetypes.ObjectAsOptions{})
+	return &out, d
+}
+
+// DataEgressSpecAzureToObject encodes a typed struct back into types.Object.
+// A nil receiver returns types.ObjectNull with the correct attribute types.
+func DataEgressSpecAzureToObject(ctx context.Context, v *DataEgressSpecAzureModel) (types.Object, diag.Diagnostics) {
+	if v == nil {
+		return types.ObjectNull(DataEgressSpecAzureAttrTypes()), nil
+	}
+	return types.ObjectValueFrom(ctx, DataEgressSpecAzureAttrTypes(), v)
 }

--- a/redpanda/models/network/data_model_gen.go
+++ b/redpanda/models/network/data_model_gen.go
@@ -109,6 +109,7 @@ type DataCustomerManagedResourcesGCPManagementBucketModel struct {
 // converters on the parent struct to move between types.Object and this
 // typed form.
 type DataEgressSpecModel struct {
+<<<<<<< HEAD
 	Azure types.Object `tfsdk:"azure"`
 }
 
@@ -118,6 +119,16 @@ type DataEgressSpecModel struct {
 type DataEgressSpecAzureModel struct {
 	FirewallPrivateIp types.String `tfsdk:"firewall_private_ip"`
 	HubVnetID         types.String `tfsdk:"hub_vnet_id"`
+=======
+	AWS types.Object `tfsdk:"aws"`
+}
+
+// DataEgressSpecAWSModel mirrors the nested "egress_spec.aws" attribute. Use the As/To
+// converters on the parent struct to move between types.Object and this
+// typed form.
+type DataEgressSpecAWSModel struct {
+	TransitGatewayID types.String `tfsdk:"transit_gateway_id"`
+>>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
 }
 
 // --- AttrType tables for nested types (consumed by types.ObjectValueFrom / ObjectNull) ---
@@ -196,6 +207,7 @@ func DataCustomerManagedResourcesGCPManagementBucketAttrTypes() map[string]attr.
 // attribute.
 func DataEgressSpecAttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
+<<<<<<< HEAD
 		"azure": types.ObjectType{AttrTypes: DataEgressSpecAzureAttrTypes()},
 	}
 }
@@ -206,6 +218,17 @@ func DataEgressSpecAzureAttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
 		"firewall_private_ip": types.StringType,
 		"hub_vnet_id":         types.StringType,
+=======
+		"aws": types.ObjectType{AttrTypes: DataEgressSpecAWSAttrTypes()},
+	}
+}
+
+// DataEgressSpecAWSAttrTypes returns the attr.Type map for the "egress_spec.aws" nested
+// attribute.
+func DataEgressSpecAWSAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"transit_gateway_id": types.StringType,
+>>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
 	}
 }
 
@@ -399,6 +422,7 @@ func DataCustomerManagedResourcesGCPManagementBucketToObject(ctx context.Context
 	return types.ObjectValueFrom(ctx, DataCustomerManagedResourcesGCPManagementBucketAttrTypes(), v)
 }
 
+<<<<<<< HEAD
 // DecodeDataEgressSpecAzure decodes the sub-field from its parent typed struct.
 // Returns (nil, nil) when the field is null or unknown.
 func DecodeDataEgressSpecAzure(ctx context.Context, v *DataEgressSpecModel) (*DataEgressSpecAzureModel, diag.Diagnostics) {
@@ -417,4 +441,24 @@ func DataEgressSpecAzureToObject(ctx context.Context, v *DataEgressSpecAzureMode
 		return types.ObjectNull(DataEgressSpecAzureAttrTypes()), nil
 	}
 	return types.ObjectValueFrom(ctx, DataEgressSpecAzureAttrTypes(), v)
+=======
+// DecodeDataEgressSpecAWS decodes the sub-field from its parent typed struct.
+// Returns (nil, nil) when the field is null or unknown.
+func DecodeDataEgressSpecAWS(ctx context.Context, v *DataEgressSpecModel) (*DataEgressSpecAWSModel, diag.Diagnostics) {
+	if v == nil || v.AWS.IsNull() || v.AWS.IsUnknown() {
+		return nil, nil
+	}
+	var out DataEgressSpecAWSModel
+	d := v.AWS.As(ctx, &out, basetypes.ObjectAsOptions{})
+	return &out, d
+}
+
+// DataEgressSpecAWSToObject encodes a typed struct back into types.Object.
+// A nil receiver returns types.ObjectNull with the correct attribute types.
+func DataEgressSpecAWSToObject(ctx context.Context, v *DataEgressSpecAWSModel) (types.Object, diag.Diagnostics) {
+	if v == nil {
+		return types.ObjectNull(DataEgressSpecAWSAttrTypes()), nil
+	}
+	return types.ObjectValueFrom(ctx, DataEgressSpecAWSAttrTypes(), v)
+>>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
 }

--- a/redpanda/models/network/resource_model_gen.go
+++ b/redpanda/models/network/resource_model_gen.go
@@ -111,6 +111,7 @@ type CustomerManagedResourcesGCPManagementBucketModel struct {
 // converters on the parent struct to move between types.Object and this
 // typed form.
 type EgressSpecModel struct {
+<<<<<<< HEAD
 	Azure types.Object `tfsdk:"azure"`
 }
 
@@ -120,6 +121,16 @@ type EgressSpecModel struct {
 type EgressSpecAzureModel struct {
 	FirewallPrivateIp types.String `tfsdk:"firewall_private_ip"`
 	HubVnetID         types.String `tfsdk:"hub_vnet_id"`
+=======
+	AWS types.Object `tfsdk:"aws"`
+}
+
+// EgressSpecAWSModel mirrors the nested "egress_spec.aws" attribute. Use the As/To
+// converters on the parent struct to move between types.Object and this
+// typed form.
+type EgressSpecAWSModel struct {
+	TransitGatewayID types.String `tfsdk:"transit_gateway_id"`
+>>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
 }
 
 // --- AttrType tables for nested types (consumed by types.ObjectValueFrom / ObjectNull) ---
@@ -198,6 +209,7 @@ func CustomerManagedResourcesGCPManagementBucketAttrTypes() map[string]attr.Type
 // attribute.
 func EgressSpecAttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
+<<<<<<< HEAD
 		"azure": types.ObjectType{AttrTypes: EgressSpecAzureAttrTypes()},
 	}
 }
@@ -208,6 +220,17 @@ func EgressSpecAzureAttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
 		"firewall_private_ip": types.StringType,
 		"hub_vnet_id":         types.StringType,
+=======
+		"aws": types.ObjectType{AttrTypes: EgressSpecAWSAttrTypes()},
+	}
+}
+
+// EgressSpecAWSAttrTypes returns the attr.Type map for the "egress_spec.aws" nested
+// attribute.
+func EgressSpecAWSAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"transit_gateway_id": types.StringType,
+>>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
 	}
 }
 
@@ -401,6 +424,7 @@ func CustomerManagedResourcesGCPManagementBucketToObject(ctx context.Context, v 
 	return types.ObjectValueFrom(ctx, CustomerManagedResourcesGCPManagementBucketAttrTypes(), v)
 }
 
+<<<<<<< HEAD
 // DecodeEgressSpecAzure decodes the sub-field from its parent typed struct.
 // Returns (nil, nil) when the field is null or unknown.
 func DecodeEgressSpecAzure(ctx context.Context, v *EgressSpecModel) (*EgressSpecAzureModel, diag.Diagnostics) {
@@ -419,6 +443,26 @@ func EgressSpecAzureToObject(ctx context.Context, v *EgressSpecAzureModel) (type
 		return types.ObjectNull(EgressSpecAzureAttrTypes()), nil
 	}
 	return types.ObjectValueFrom(ctx, EgressSpecAzureAttrTypes(), v)
+=======
+// DecodeEgressSpecAWS decodes the sub-field from its parent typed struct.
+// Returns (nil, nil) when the field is null or unknown.
+func DecodeEgressSpecAWS(ctx context.Context, v *EgressSpecModel) (*EgressSpecAWSModel, diag.Diagnostics) {
+	if v == nil || v.AWS.IsNull() || v.AWS.IsUnknown() {
+		return nil, nil
+	}
+	var out EgressSpecAWSModel
+	d := v.AWS.As(ctx, &out, basetypes.ObjectAsOptions{})
+	return &out, d
+}
+
+// EgressSpecAWSToObject encodes a typed struct back into types.Object.
+// A nil receiver returns types.ObjectNull with the correct attribute types.
+func EgressSpecAWSToObject(ctx context.Context, v *EgressSpecAWSModel) (types.Object, diag.Diagnostics) {
+	if v == nil {
+		return types.ObjectNull(EgressSpecAWSAttrTypes()), nil
+	}
+	return types.ObjectValueFrom(ctx, EgressSpecAWSAttrTypes(), v)
+>>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
 }
 
 // GenerateMinimalResourceModel returns a *ResourceModel populated only with

--- a/redpanda/models/network/resource_model_gen.go
+++ b/redpanda/models/network/resource_model_gen.go
@@ -111,8 +111,15 @@ type CustomerManagedResourcesGCPManagementBucketModel struct {
 // converters on the parent struct to move between types.Object and this
 // typed form.
 type EgressSpecModel struct {
-<<<<<<< HEAD
+	AWS   types.Object `tfsdk:"aws"`
 	Azure types.Object `tfsdk:"azure"`
+}
+
+// EgressSpecAWSModel mirrors the nested "egress_spec.aws" attribute. Use the As/To
+// converters on the parent struct to move between types.Object and this
+// typed form.
+type EgressSpecAWSModel struct {
+	TransitGatewayID types.String `tfsdk:"transit_gateway_id"`
 }
 
 // EgressSpecAzureModel mirrors the nested "egress_spec.azure" attribute. Use the As/To
@@ -121,16 +128,6 @@ type EgressSpecModel struct {
 type EgressSpecAzureModel struct {
 	FirewallPrivateIp types.String `tfsdk:"firewall_private_ip"`
 	HubVnetID         types.String `tfsdk:"hub_vnet_id"`
-=======
-	AWS types.Object `tfsdk:"aws"`
-}
-
-// EgressSpecAWSModel mirrors the nested "egress_spec.aws" attribute. Use the As/To
-// converters on the parent struct to move between types.Object and this
-// typed form.
-type EgressSpecAWSModel struct {
-	TransitGatewayID types.String `tfsdk:"transit_gateway_id"`
->>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
 }
 
 // --- AttrType tables for nested types (consumed by types.ObjectValueFrom / ObjectNull) ---
@@ -209,8 +206,16 @@ func CustomerManagedResourcesGCPManagementBucketAttrTypes() map[string]attr.Type
 // attribute.
 func EgressSpecAttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
-<<<<<<< HEAD
+		"aws":   types.ObjectType{AttrTypes: EgressSpecAWSAttrTypes()},
 		"azure": types.ObjectType{AttrTypes: EgressSpecAzureAttrTypes()},
+	}
+}
+
+// EgressSpecAWSAttrTypes returns the attr.Type map for the "egress_spec.aws" nested
+// attribute.
+func EgressSpecAWSAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"transit_gateway_id": types.StringType,
 	}
 }
 
@@ -220,17 +225,6 @@ func EgressSpecAzureAttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
 		"firewall_private_ip": types.StringType,
 		"hub_vnet_id":         types.StringType,
-=======
-		"aws": types.ObjectType{AttrTypes: EgressSpecAWSAttrTypes()},
-	}
-}
-
-// EgressSpecAWSAttrTypes returns the attr.Type map for the "egress_spec.aws" nested
-// attribute.
-func EgressSpecAWSAttrTypes() map[string]attr.Type {
-	return map[string]attr.Type{
-		"transit_gateway_id": types.StringType,
->>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
 	}
 }
 
@@ -424,26 +418,6 @@ func CustomerManagedResourcesGCPManagementBucketToObject(ctx context.Context, v 
 	return types.ObjectValueFrom(ctx, CustomerManagedResourcesGCPManagementBucketAttrTypes(), v)
 }
 
-<<<<<<< HEAD
-// DecodeEgressSpecAzure decodes the sub-field from its parent typed struct.
-// Returns (nil, nil) when the field is null or unknown.
-func DecodeEgressSpecAzure(ctx context.Context, v *EgressSpecModel) (*EgressSpecAzureModel, diag.Diagnostics) {
-	if v == nil || v.Azure.IsNull() || v.Azure.IsUnknown() {
-		return nil, nil
-	}
-	var out EgressSpecAzureModel
-	d := v.Azure.As(ctx, &out, basetypes.ObjectAsOptions{})
-	return &out, d
-}
-
-// EgressSpecAzureToObject encodes a typed struct back into types.Object.
-// A nil receiver returns types.ObjectNull with the correct attribute types.
-func EgressSpecAzureToObject(ctx context.Context, v *EgressSpecAzureModel) (types.Object, diag.Diagnostics) {
-	if v == nil {
-		return types.ObjectNull(EgressSpecAzureAttrTypes()), nil
-	}
-	return types.ObjectValueFrom(ctx, EgressSpecAzureAttrTypes(), v)
-=======
 // DecodeEgressSpecAWS decodes the sub-field from its parent typed struct.
 // Returns (nil, nil) when the field is null or unknown.
 func DecodeEgressSpecAWS(ctx context.Context, v *EgressSpecModel) (*EgressSpecAWSModel, diag.Diagnostics) {
@@ -462,7 +436,26 @@ func EgressSpecAWSToObject(ctx context.Context, v *EgressSpecAWSModel) (types.Ob
 		return types.ObjectNull(EgressSpecAWSAttrTypes()), nil
 	}
 	return types.ObjectValueFrom(ctx, EgressSpecAWSAttrTypes(), v)
->>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
+}
+
+// DecodeEgressSpecAzure decodes the sub-field from its parent typed struct.
+// Returns (nil, nil) when the field is null or unknown.
+func DecodeEgressSpecAzure(ctx context.Context, v *EgressSpecModel) (*EgressSpecAzureModel, diag.Diagnostics) {
+	if v == nil || v.Azure.IsNull() || v.Azure.IsUnknown() {
+		return nil, nil
+	}
+	var out EgressSpecAzureModel
+	d := v.Azure.As(ctx, &out, basetypes.ObjectAsOptions{})
+	return &out, d
+}
+
+// EgressSpecAzureToObject encodes a typed struct back into types.Object.
+// A nil receiver returns types.ObjectNull with the correct attribute types.
+func EgressSpecAzureToObject(ctx context.Context, v *EgressSpecAzureModel) (types.Object, diag.Diagnostics) {
+	if v == nil {
+		return types.ObjectNull(EgressSpecAzureAttrTypes()), nil
+	}
+	return types.ObjectValueFrom(ctx, EgressSpecAzureAttrTypes(), v)
 }
 
 // GenerateMinimalResourceModel returns a *ResourceModel populated only with

--- a/redpanda/resources/network/integration_network_test.go
+++ b/redpanda/resources/network/integration_network_test.go
@@ -603,8 +603,8 @@ func TestIntegration_Network_RequiresReplace_CMR_GCP(t *testing.T) {
 	})
 }
 
-// hubEgressAzureConfig builds an Azure network variant with a hub-VNet egress_spec.
-func hubEgressAzureConfig(name, hubVnetID, firewallIP string) string {
+// tgwAWSConfig builds an AWS network variant with a Transit Gateway egress_spec.
+func tgwAWSConfig(name, tgwID string) string {
 	return fmt.Sprintf(`
 provider "redpanda" {}
 
@@ -615,31 +615,29 @@ resource "redpanda_resource_group" "test" {
 resource "redpanda_network" "test" {
   name              = %q
   resource_group_id = redpanda_resource_group.test.id
-  cloud_provider    = "azure"
-  region            = "westus2"
+  cloud_provider    = "aws"
+  region            = "us-east-1"
   cluster_type      = "dedicated"
   cidr_block        = "10.0.0.0/20"
   egress_spec = {
-    azure = {
-      hub_vnet_id         = %q
-      firewall_private_ip = %q
+    aws = {
+      transit_gateway_id = %q
     }
   }
 }
-`, name, hubVnetID, firewallIP)
+`, name, tgwID)
 }
 
-// TestIntegration_Network_CreateAndRefresh_AzureHubEgress validates the Create +
-// no-op cycle for the Azure hub-VNet egress_spec variant.
-func TestIntegration_Network_CreateAndRefresh_AzureHubEgress(t *testing.T) {
+// TestIntegration_Network_CreateAndRefresh_TGW validates the Create + no-op cycle
+// for the AWS Transit Gateway egress_spec variant.
+func TestIntegration_Network_CreateAndRefresh_TGW(t *testing.T) {
 	_, factories := integration.Setup(t)
 
 	const (
-		name       = "tfrp-mock-net-hub-create"
-		hubVnetID  = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/hub-vnet"
-		firewallIP = "10.1.0.4"
+		name  = "tfrp-mock-net-tgw-create"
+		tgwID = "tgw-0123456789abcdef0"
 	)
-	cfg := hubEgressAzureConfig(name, hubVnetID, firewallIP)
+	cfg := tgwAWSConfig(name, tgwID)
 
 	idPreserved := statecheck.CompareValue(compare.ValuesSame())
 
@@ -649,18 +647,15 @@ func TestIntegration_Network_CreateAndRefresh_AzureHubEgress(t *testing.T) {
 			integration.CreateStep(networkAddr, cfg, []statecheck.StateCheck{
 				statecheck.ExpectKnownValue(networkAddr, tfjsonpath.New("name"), knownvalue.StringExact(name)),
 				statecheck.ExpectKnownValue(networkAddr,
-					tfjsonpath.New("egress_spec").AtMapKey("azure").AtMapKey("hub_vnet_id"),
-					knownvalue.StringExact(hubVnetID)),
-				statecheck.ExpectKnownValue(networkAddr,
-					tfjsonpath.New("egress_spec").AtMapKey("azure").AtMapKey("firewall_private_ip"),
-					knownvalue.StringExact(firewallIP)),
+					tfjsonpath.New("egress_spec").AtMapKey("aws").AtMapKey("transit_gateway_id"),
+					knownvalue.StringExact(tgwID)),
 				statecheck.ExpectKnownValue(networkAddr, tfjsonpath.New("id"), knownvalue.NotNull()),
 				idPreserved.AddStateValue(networkAddr, tfjsonpath.New("id")),
 			}),
 			integration.NoopReapplyStep(networkAddr, cfg, []statecheck.StateCheck{
 				statecheck.ExpectKnownValue(networkAddr,
-					tfjsonpath.New("egress_spec").AtMapKey("azure").AtMapKey("hub_vnet_id"),
-					knownvalue.StringExact(hubVnetID)),
+					tfjsonpath.New("egress_spec").AtMapKey("aws").AtMapKey("transit_gateway_id"),
+					knownvalue.StringExact(tgwID)),
 				statecheck.ExpectKnownValue(networkAddr, tfjsonpath.New("id"), knownvalue.NotNull()),
 				idPreserved.AddStateValue(networkAddr, tfjsonpath.New("id")),
 			}),
@@ -668,17 +663,16 @@ func TestIntegration_Network_CreateAndRefresh_AzureHubEgress(t *testing.T) {
 	})
 }
 
-// TestIntegration_Network_RequiresReplace_AzureHubEgress mutates
-// egress_spec.azure.firewall_private_ip and asserts DestroyBeforeCreate.
-// egress_spec.azure carries RequiresReplace since Network has no Update RPC.
-func TestIntegration_Network_RequiresReplace_AzureHubEgress(t *testing.T) {
+// TestIntegration_Network_RequiresReplace_TGW mutates egress_spec.aws.transit_gateway_id
+// and asserts DestroyBeforeCreate. egress_spec.aws carries RequiresReplace since
+// Network has no Update RPC.
+func TestIntegration_Network_RequiresReplace_TGW(t *testing.T) {
 	_, factories := integration.Setup(t)
 
 	const (
-		name        = "tfrp-mock-net-rr-hub"
-		hubVnetID   = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/hub-vnet"
-		firewallIPA = "10.1.0.4"
-		firewallIPB = "10.1.0.5"
+		name   = "tfrp-mock-net-rr-tgw"
+		tgwIDA = "tgw-0123456789abcdef0"
+		tgwIDB = "tgw-fedcba9876543210f"
 	)
 
 	idChanged := statecheck.CompareValue(compare.ValuesDiffer())
@@ -686,17 +680,17 @@ func TestIntegration_Network_RequiresReplace_AzureHubEgress(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: factories,
 		Steps: []resource.TestStep{
-			integration.CreateStep(networkAddr, hubEgressAzureConfig(name, hubVnetID, firewallIPA), []statecheck.StateCheck{
+			integration.CreateStep(networkAddr, tgwAWSConfig(name, tgwIDA), []statecheck.StateCheck{
 				statecheck.ExpectKnownValue(networkAddr,
-					tfjsonpath.New("egress_spec").AtMapKey("azure").AtMapKey("firewall_private_ip"),
-					knownvalue.StringExact(firewallIPA)),
+					tfjsonpath.New("egress_spec").AtMapKey("aws").AtMapKey("transit_gateway_id"),
+					knownvalue.StringExact(tgwIDA)),
 				statecheck.ExpectKnownValue(networkAddr, tfjsonpath.New("id"), knownvalue.NotNull()),
 				idChanged.AddStateValue(networkAddr, tfjsonpath.New("id")),
 			}),
-			integration.RequiresReplaceStep(networkAddr, hubEgressAzureConfig(name, hubVnetID, firewallIPB), []statecheck.StateCheck{
+			integration.RequiresReplaceStep(networkAddr, tgwAWSConfig(name, tgwIDB), []statecheck.StateCheck{
 				statecheck.ExpectKnownValue(networkAddr,
-					tfjsonpath.New("egress_spec").AtMapKey("azure").AtMapKey("firewall_private_ip"),
-					knownvalue.StringExact(firewallIPB)),
+					tfjsonpath.New("egress_spec").AtMapKey("aws").AtMapKey("transit_gateway_id"),
+					knownvalue.StringExact(tgwIDB)),
 				statecheck.ExpectKnownValue(networkAddr, tfjsonpath.New("id"), knownvalue.NotNull()),
 				idChanged.AddStateValue(networkAddr, tfjsonpath.New("id")),
 			}),

--- a/redpanda/resources/network/integration_network_test.go
+++ b/redpanda/resources/network/integration_network_test.go
@@ -698,6 +698,107 @@ func TestIntegration_Network_RequiresReplace_TGW(t *testing.T) {
 	})
 }
 
+// hubEgressAzureConfig builds an Azure network variant with a hub-VNet egress_spec.
+func hubEgressAzureConfig(name, hubVnetID, firewallIP string) string {
+	return fmt.Sprintf(`
+provider "redpanda" {}
+
+resource "redpanda_resource_group" "test" {
+  name = "tfrp-mock-net-rg"
+}
+
+resource "redpanda_network" "test" {
+  name              = %q
+  resource_group_id = redpanda_resource_group.test.id
+  cloud_provider    = "azure"
+  region            = "westus2"
+  cluster_type      = "dedicated"
+  cidr_block        = "10.0.0.0/20"
+  egress_spec = {
+    azure = {
+      hub_vnet_id         = %q
+      firewall_private_ip = %q
+    }
+  }
+}
+`, name, hubVnetID, firewallIP)
+}
+
+// TestIntegration_Network_CreateAndRefresh_AzureHubEgress validates the Create +
+// no-op cycle for the Azure hub-VNet egress_spec variant.
+func TestIntegration_Network_CreateAndRefresh_AzureHubEgress(t *testing.T) {
+	_, factories := integration.Setup(t)
+
+	const (
+		name       = "tfrp-mock-net-hub-create"
+		hubVnetID  = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/hub-vnet"
+		firewallIP = "10.1.0.4"
+	)
+	cfg := hubEgressAzureConfig(name, hubVnetID, firewallIP)
+
+	idPreserved := statecheck.CompareValue(compare.ValuesSame())
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: factories,
+		Steps: []resource.TestStep{
+			integration.CreateStep(networkAddr, cfg, []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(networkAddr, tfjsonpath.New("name"), knownvalue.StringExact(name)),
+				statecheck.ExpectKnownValue(networkAddr,
+					tfjsonpath.New("egress_spec").AtMapKey("azure").AtMapKey("hub_vnet_id"),
+					knownvalue.StringExact(hubVnetID)),
+				statecheck.ExpectKnownValue(networkAddr,
+					tfjsonpath.New("egress_spec").AtMapKey("azure").AtMapKey("firewall_private_ip"),
+					knownvalue.StringExact(firewallIP)),
+				statecheck.ExpectKnownValue(networkAddr, tfjsonpath.New("id"), knownvalue.NotNull()),
+				idPreserved.AddStateValue(networkAddr, tfjsonpath.New("id")),
+			}),
+			integration.NoopReapplyStep(networkAddr, cfg, []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(networkAddr,
+					tfjsonpath.New("egress_spec").AtMapKey("azure").AtMapKey("hub_vnet_id"),
+					knownvalue.StringExact(hubVnetID)),
+				statecheck.ExpectKnownValue(networkAddr, tfjsonpath.New("id"), knownvalue.NotNull()),
+				idPreserved.AddStateValue(networkAddr, tfjsonpath.New("id")),
+			}),
+		},
+	})
+}
+
+// TestIntegration_Network_RequiresReplace_AzureHubEgress mutates
+// egress_spec.azure.firewall_private_ip and asserts DestroyBeforeCreate.
+// egress_spec.azure carries RequiresReplace since Network has no Update RPC.
+func TestIntegration_Network_RequiresReplace_AzureHubEgress(t *testing.T) {
+	_, factories := integration.Setup(t)
+
+	const (
+		name        = "tfrp-mock-net-rr-hub"
+		hubVnetID   = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/hub-vnet"
+		firewallIPA = "10.1.0.4"
+		firewallIPB = "10.1.0.5"
+	)
+
+	idChanged := statecheck.CompareValue(compare.ValuesDiffer())
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: factories,
+		Steps: []resource.TestStep{
+			integration.CreateStep(networkAddr, hubEgressAzureConfig(name, hubVnetID, firewallIPA), []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(networkAddr,
+					tfjsonpath.New("egress_spec").AtMapKey("azure").AtMapKey("firewall_private_ip"),
+					knownvalue.StringExact(firewallIPA)),
+				statecheck.ExpectKnownValue(networkAddr, tfjsonpath.New("id"), knownvalue.NotNull()),
+				idChanged.AddStateValue(networkAddr, tfjsonpath.New("id")),
+			}),
+			integration.RequiresReplaceStep(networkAddr, hubEgressAzureConfig(name, hubVnetID, firewallIPB), []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(networkAddr,
+					tfjsonpath.New("egress_spec").AtMapKey("azure").AtMapKey("firewall_private_ip"),
+					knownvalue.StringExact(firewallIPB)),
+				statecheck.ExpectKnownValue(networkAddr, tfjsonpath.New("id"), knownvalue.NotNull()),
+				idChanged.AddStateValue(networkAddr, tfjsonpath.New("id")),
+			}),
+		},
+	})
+}
+
 // TestIntegration_Network_ImportRoundTrip exercises the bearer-id import path.
 // Network's ImportState uses ImportStatePassthroughID on the "id" attribute,
 // so the import id is the xid-like string assigned at Create. Network's

--- a/redpanda/resources/network/schema.yaml
+++ b/redpanda/resources/network/schema.yaml
@@ -107,7 +107,13 @@ egress_spec:
   computed: false
   fields:
     aws:
-      todo: true
+      optional: true
+      computed: false
+      plan_modifiers: [RequiresReplace]
+      fields:
+        transit_gateway_id:
+          required: true
+          validator: TransitGatewayID
     gcp:
       todo: true
     azure:

--- a/redpanda/resources/network/schema_datasource.yaml
+++ b/redpanda/resources/network/schema_datasource.yaml
@@ -61,7 +61,8 @@ customer_managed_resources:
 egress_spec:
   fields:
     aws:
-      todo: true
+      fields:
+        transit_gateway_id: {}
     gcp:
       todo: true
     azure:

--- a/redpanda/resources/network/schema_datasource_gen.go
+++ b/redpanda/resources/network/schema_datasource_gen.go
@@ -139,6 +139,7 @@ func DatasourceNetworkSchema(_ context.Context) schema.Schema {
 				Description: "Egress Spec configuration",
 				Computed:    true,
 				Attributes: map[string]schema.Attribute{
+<<<<<<< HEAD
 					"azure": schema.SingleNestedAttribute{
 						Description: "Azure configuration",
 						Computed:    true,
@@ -149,6 +150,14 @@ func DatasourceNetworkSchema(_ context.Context) schema.Schema {
 							},
 							"hub_vnet_id": schema.StringAttribute{
 								Description: "Hub Vnet ID",
+=======
+					"aws": schema.SingleNestedAttribute{
+						Description: "AWS configuration",
+						Computed:    true,
+						Attributes: map[string]schema.Attribute{
+							"transit_gateway_id": schema.StringAttribute{
+								Description: "Transit Gateway ID",
+>>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
 								Computed:    true,
 							},
 						},

--- a/redpanda/resources/network/schema_datasource_gen.go
+++ b/redpanda/resources/network/schema_datasource_gen.go
@@ -139,7 +139,16 @@ func DatasourceNetworkSchema(_ context.Context) schema.Schema {
 				Description: "Egress Spec configuration",
 				Computed:    true,
 				Attributes: map[string]schema.Attribute{
-<<<<<<< HEAD
+					"aws": schema.SingleNestedAttribute{
+						Description: "AWS configuration",
+						Computed:    true,
+						Attributes: map[string]schema.Attribute{
+							"transit_gateway_id": schema.StringAttribute{
+								Description: "Transit Gateway ID",
+								Computed:    true,
+							},
+						},
+					},
 					"azure": schema.SingleNestedAttribute{
 						Description: "Azure configuration",
 						Computed:    true,
@@ -150,14 +159,6 @@ func DatasourceNetworkSchema(_ context.Context) schema.Schema {
 							},
 							"hub_vnet_id": schema.StringAttribute{
 								Description: "Hub Vnet ID",
-=======
-					"aws": schema.SingleNestedAttribute{
-						Description: "AWS configuration",
-						Computed:    true,
-						Attributes: map[string]schema.Attribute{
-							"transit_gateway_id": schema.StringAttribute{
-								Description: "Transit Gateway ID",
->>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
 								Computed:    true,
 							},
 						},

--- a/redpanda/resources/network/schema_resource_gen.go
+++ b/redpanda/resources/network/schema_resource_gen.go
@@ -170,6 +170,7 @@ func ResourceNetworkSchema(ctx context.Context) schema.Schema {
 				Description: "Egress Spec configuration",
 				Optional:    true,
 				Attributes: map[string]schema.Attribute{
+<<<<<<< HEAD
 					"azure": schema.SingleNestedAttribute{
 						Description:   "Azure configuration",
 						Optional:      true,
@@ -183,6 +184,20 @@ func ResourceNetworkSchema(ctx context.Context) schema.Schema {
 							"hub_vnet_id": schema.StringAttribute{
 								Description: "Hub Vnet ID. Length must be at least 1.",
 								Required:    true,
+=======
+					"aws": schema.SingleNestedAttribute{
+						Description:   "AWS configuration",
+						Optional:      true,
+						PlanModifiers: []planmodifier.Object{objectplanmodifier.RequiresReplace()},
+						Attributes: map[string]schema.Attribute{
+							"transit_gateway_id": schema.StringAttribute{
+								Description: "Transit Gateway ID. Must match pattern `^tgw-[0-9a-f]{8,}$`.",
+								Required:    true,
+								Validators: []validator.String{stringvalidator.RegexMatches(
+									regexp.MustCompile(`^tgw-[0-9a-f]{8,}$`),
+									"must be a valid AWS Transit Gateway ID (e.g., tgw-0123456789abcdef0)",
+								)},
+>>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
 							},
 						},
 					},

--- a/redpanda/resources/network/schema_resource_gen.go
+++ b/redpanda/resources/network/schema_resource_gen.go
@@ -170,7 +170,21 @@ func ResourceNetworkSchema(ctx context.Context) schema.Schema {
 				Description: "Egress Spec configuration",
 				Optional:    true,
 				Attributes: map[string]schema.Attribute{
-<<<<<<< HEAD
+					"aws": schema.SingleNestedAttribute{
+						Description:   "AWS configuration",
+						Optional:      true,
+						PlanModifiers: []planmodifier.Object{objectplanmodifier.RequiresReplace()},
+						Attributes: map[string]schema.Attribute{
+							"transit_gateway_id": schema.StringAttribute{
+								Description: "Transit Gateway ID. Must match pattern `^tgw-[0-9a-f]{8,}$`.",
+								Required:    true,
+								Validators: []validator.String{stringvalidator.RegexMatches(
+									regexp.MustCompile(`^tgw-[0-9a-f]{8,}$`),
+									"must be a valid AWS Transit Gateway ID (e.g., tgw-0123456789abcdef0)",
+								)},
+							},
+						},
+					},
 					"azure": schema.SingleNestedAttribute{
 						Description:   "Azure configuration",
 						Optional:      true,
@@ -184,20 +198,6 @@ func ResourceNetworkSchema(ctx context.Context) schema.Schema {
 							"hub_vnet_id": schema.StringAttribute{
 								Description: "Hub Vnet ID. Length must be at least 1.",
 								Required:    true,
-=======
-					"aws": schema.SingleNestedAttribute{
-						Description:   "AWS configuration",
-						Optional:      true,
-						PlanModifiers: []planmodifier.Object{objectplanmodifier.RequiresReplace()},
-						Attributes: map[string]schema.Attribute{
-							"transit_gateway_id": schema.StringAttribute{
-								Description: "Transit Gateway ID. Must match pattern `^tgw-[0-9a-f]{8,}$`.",
-								Required:    true,
-								Validators: []validator.String{stringvalidator.RegexMatches(
-									regexp.MustCompile(`^tgw-[0-9a-f]{8,}$`),
-									"must be a valid AWS Transit Gateway ID (e.g., tgw-0123456789abcdef0)",
-								)},
->>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
 							},
 						},
 					},

--- a/redpanda/resources/testdata/network_datasource_schema.golden
+++ b/redpanda/resources/testdata/network_datasource_schema.golden
@@ -72,6 +72,7 @@ attributes:
       type: SingleNestedAttribute
       computed: true
       attributes:
+<<<<<<< HEAD
         - name: azure
           type: SingleNestedAttribute
           computed: true
@@ -80,6 +81,13 @@ attributes:
               type: StringAttribute
               computed: true
             - name: hub_vnet_id
+=======
+        - name: aws
+          type: SingleNestedAttribute
+          computed: true
+          attributes:
+            - name: transit_gateway_id
+>>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
               type: StringAttribute
               computed: true
     - name: id

--- a/redpanda/resources/testdata/network_datasource_schema.golden
+++ b/redpanda/resources/testdata/network_datasource_schema.golden
@@ -72,7 +72,13 @@ attributes:
       type: SingleNestedAttribute
       computed: true
       attributes:
-<<<<<<< HEAD
+        - name: aws
+          type: SingleNestedAttribute
+          computed: true
+          attributes:
+            - name: transit_gateway_id
+              type: StringAttribute
+              computed: true
         - name: azure
           type: SingleNestedAttribute
           computed: true
@@ -81,13 +87,6 @@ attributes:
               type: StringAttribute
               computed: true
             - name: hub_vnet_id
-=======
-        - name: aws
-          type: SingleNestedAttribute
-          computed: true
-          attributes:
-            - name: transit_gateway_id
->>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
               type: StringAttribute
               computed: true
     - name: id

--- a/redpanda/resources/testdata/network_resource_schema.golden
+++ b/redpanda/resources/testdata/network_resource_schema.golden
@@ -91,12 +91,17 @@ attributes:
       type: SingleNestedAttribute
       optional: true
       attributes:
+<<<<<<< HEAD
         - name: azure
+=======
+        - name: aws
+>>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
           type: SingleNestedAttribute
           optional: true
           plan_modifiers:
             - objectplanmodifier.requiresReplaceIfModifier
           attributes:
+<<<<<<< HEAD
             - name: firewall_private_ip
               type: StringAttribute
               required: true
@@ -105,6 +110,13 @@ attributes:
             - name: hub_vnet_id
               type: StringAttribute
               required: true
+=======
+            - name: transit_gateway_id
+              type: StringAttribute
+              required: true
+              validators:
+                - stringvalidator.regexMatchesValidator
+>>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
     - name: id
       type: StringAttribute
       computed: true

--- a/redpanda/resources/testdata/network_resource_schema.golden
+++ b/redpanda/resources/testdata/network_resource_schema.golden
@@ -91,17 +91,23 @@ attributes:
       type: SingleNestedAttribute
       optional: true
       attributes:
-<<<<<<< HEAD
-        - name: azure
-=======
         - name: aws
->>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
           type: SingleNestedAttribute
           optional: true
           plan_modifiers:
             - objectplanmodifier.requiresReplaceIfModifier
           attributes:
-<<<<<<< HEAD
+            - name: transit_gateway_id
+              type: StringAttribute
+              required: true
+              validators:
+                - stringvalidator.regexMatchesValidator
+        - name: azure
+          type: SingleNestedAttribute
+          optional: true
+          plan_modifiers:
+            - objectplanmodifier.requiresReplaceIfModifier
+          attributes:
             - name: firewall_private_ip
               type: StringAttribute
               required: true
@@ -110,13 +116,6 @@ attributes:
             - name: hub_vnet_id
               type: StringAttribute
               required: true
-=======
-            - name: transit_gateway_id
-              type: StringAttribute
-              required: true
-              validators:
-                - stringvalidator.regexMatchesValidator
->>>>>>> d3c400dd (chore(generate): regenerate network schema, model, golden, and docs)
     - name: id
       type: StringAttribute
       computed: true


### PR DESCRIPTION
Summary

Adds AWS Transit Gateway (TGW) egress support to redpanda_network via a new egress_spec.aws block, wiring transit_gateway_id. This lets BYOC clusters route outbound internet traffic through an existing customer-managed AWS Transit Gateway instead of provisioning a per-network NAT Gateway / Internet Gateway:

- transit_gateway_id — ID of an existing AWS Transit Gateway shared with Redpanda's account for centralized egress; when set, the spoke VPC attaches to it and all internet-bound traffic routes through the customer's hub VPC via the TGW

The block is RequiresReplace, since redpanda_network has no Update RPC and egress_spec is immutable at the API descriptor level.

This is the AWS arm of the egress_spec oneof; sibling PRs cover GCP (hub_vpc_project/hub_vpc_name) and Azure (hub_vnet_id/firewall_private_ip). The gcp/azure arms remain todo: true on this branch.

```
resource "redpanda_network" "example" {
  name              = "example"
  cloud_provider    = "aws"
  region            = "us-east-1"
  cluster_type      = "byoc"
  egress_spec = {
    aws = {
      transit_gateway_id = "tgw-0123456789abcdef0"
    }
  }
}
```

Notes for reviewers

- Added a TransitGatewayID validator (internal/schemagen/validators.go) — stringvalidator.RegexMatches against ^tgw-[0-9a-f]{8,}$ — mirroring the API's own buf.validate.field pattern constraint on this field, so client-side validation matches the backend exactly.
- Fixed NetworkFake.CreateNetwork (internal/testutil/mock/fakes/network.go), which wasn't copying EgressSpec into stored state — it would have round-tripped as null on Read in the mock-backed integration tests.
- redpanda/resources/network/{schema,schema_datasource}.yaml are the only hand-edited schema files; *_gen.go, golden files, and docs are regenerated output.

Test plan

- [x] task test:unit
- [x] task test:integration (new TestIntegration_Network_CreateAndRefresh_TGW / TestIntegration_Network_RequiresReplace_TGW, plus full existing suite passing)
- [x] task lint — 0 issues
- [x] task docs — regenerated, diff committed
- [ ] Live acc test against a real AWS BYOC network