### PR TITLE
Update redpanda terraform provider to support VPC Hub (GCP)

### DIFF
--- a/docs/data-sources/network.md
+++ b/docs/data-sources/network.md
@@ -106,6 +106,7 @@ Read-Only:
 
 - `aws` (Attributes) AWS configuration (see [below for nested schema](#nestedatt--egress_spec--aws))
 - `azure` (Attributes) Azure configuration (see [below for nested schema](#nestedatt--egress_spec--azure))
+- `gcp` (Attributes) GCP configuration (see [below for nested schema](#nestedatt--egress_spec--gcp))
 
 <a id="nestedatt--egress_spec--aws"></a>
 ### Nested Schema for `egress_spec.aws`
@@ -122,6 +123,15 @@ Read-Only:
 
 - `firewall_private_ip` (String) Firewall Private Ip
 - `hub_vnet_id` (String) Hub Vnet ID
+
+
+<a id="nestedatt--egress_spec--gcp"></a>
+### Nested Schema for `egress_spec.gcp`
+
+Read-Only:
+
+- `hub_vpc_name` (String) Hub VPC Name
+- `hub_vpc_project` (String) Hub VPC Project
 
 ## Usage
 

--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -112,6 +112,7 @@ Optional:
 
 - `aws` (Attributes) AWS configuration (see [below for nested schema](#nestedatt--egress_spec--aws))
 - `azure` (Attributes) Azure configuration (see [below for nested schema](#nestedatt--egress_spec--azure))
+- `gcp` (Attributes) GCP configuration (see [below for nested schema](#nestedatt--egress_spec--gcp))
 
 <a id="nestedatt--egress_spec--aws"></a>
 ### Nested Schema for `egress_spec.aws`
@@ -128,6 +129,15 @@ Required:
 
 - `firewall_private_ip` (String) Firewall Private Ip. Must be a valid IP address.
 - `hub_vnet_id` (String) Hub Vnet ID. Length must be at least 1.
+
+
+<a id="nestedatt--egress_spec--gcp"></a>
+### Nested Schema for `egress_spec.gcp`
+
+Required:
+
+- `hub_vpc_name` (String) Hub VPC Name. Length must be at least 1.
+- `hub_vpc_project` (String) Hub VPC Project. Length must be at least 1.
 
 
 

--- a/redpanda/models/network/conv_gen.go
+++ b/redpanda/models/network/conv_gen.go
@@ -341,6 +341,7 @@ func FlattenEgressSpec(ctx context.Context, proto *controlplanev1.Network_Egress
 	m := EgressSpecModel{}
 	m.AWS = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetAws(), func() *EgressSpecAWSModel { v, _ := DecodeEgressSpecAWS(ctx, prev); return v }(), EgressSpecAWSAttrTypes(), FlattenEgressSpecAWS, &diags)
 	m.Azure = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetAzure(), func() *EgressSpecAzureModel { v, _ := DecodeEgressSpecAzure(ctx, prev); return v }(), EgressSpecAzureAttrTypes(), FlattenEgressSpecAzure, &diags)
+	m.GCP = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetGcp(), func() *EgressSpecGCPModel { v, _ := DecodeEgressSpecGCP(ctx, prev); return v }(), EgressSpecGCPAttrTypes(), FlattenEgressSpecGCP, &diags)
 	return m, diags
 }
 
@@ -356,6 +357,9 @@ func ExpandEgressSpec(ctx context.Context, m *EgressSpecModel) (*controlplanev1.
 	}
 	if v := modelconv.ObjectToMessageWithDiags(ctx, m.Azure, ExpandEgressSpecAzure, &diags); v != nil {
 		out.SetAzure(v)
+	}
+	if v := modelconv.ObjectToMessageWithDiags(ctx, m.GCP, ExpandEgressSpecGCP, &diags); v != nil {
+		out.SetGcp(v)
 	}
 	return out, diags
 }
@@ -408,6 +412,33 @@ func ExpandEgressSpecAzure(_ context.Context, m *EgressSpecAzureModel) (*control
 	out := &controlplanev1.Network_EgressSpec_Azure{
 		FirewallPrivateIp: m.FirewallPrivateIp.ValueString(),
 		HubVnetId:         m.HubVnetID.ValueString(),
+	}
+	return out, diags
+}
+
+// FlattenEgressSpecGCP converts a single proto controlplanev1.Network_EgressSpec_GCP into the
+// corresponding nested model. The prev *EgressSpecGCPModel arg carries forward
+// TF-only / sensitive / write-only fields and resolves the proto3
+// null-vs-empty ambiguity for Optional-only scalar leaves (Required leaves
+// flatten directly); pass nil when no prior nested state is available.
+func FlattenEgressSpecGCP(_ context.Context, proto *controlplanev1.Network_EgressSpec_GCP, prev *EgressSpecGCPModel) (EgressSpecGCPModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	_ = prev
+	m := EgressSpecGCPModel{}
+	m.HubVPCName = types.StringValue(proto.GetHubVpcName())
+	m.HubVPCProject = types.StringValue(proto.GetHubVpcProject())
+	return m, diags
+}
+
+// ExpandEgressSpecGCP renders a nested model back into the proto type.
+func ExpandEgressSpecGCP(_ context.Context, m *EgressSpecGCPModel) (*controlplanev1.Network_EgressSpec_GCP, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if m == nil {
+		return nil, diags
+	}
+	out := &controlplanev1.Network_EgressSpec_GCP{
+		HubVpcName:    m.HubVPCName.ValueString(),
+		HubVpcProject: m.HubVPCProject.ValueString(),
 	}
 	return out, diags
 }

--- a/redpanda/models/network/data_conv_gen.go
+++ b/redpanda/models/network/data_conv_gen.go
@@ -308,6 +308,7 @@ func FlattenDataEgressSpec(ctx context.Context, proto *controlplanev1.Network_Eg
 	m := DataEgressSpecModel{}
 	m.AWS = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetAws(), func() *DataEgressSpecAWSModel { v, _ := DecodeDataEgressSpecAWS(ctx, prev); return v }(), DataEgressSpecAWSAttrTypes(), FlattenDataEgressSpecAWS, &diags)
 	m.Azure = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetAzure(), func() *DataEgressSpecAzureModel { v, _ := DecodeDataEgressSpecAzure(ctx, prev); return v }(), DataEgressSpecAzureAttrTypes(), FlattenDataEgressSpecAzure, &diags)
+	m.GCP = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetGcp(), func() *DataEgressSpecGCPModel { v, _ := DecodeDataEgressSpecGCP(ctx, prev); return v }(), DataEgressSpecGCPAttrTypes(), FlattenDataEgressSpecGCP, &diags)
 	return m, diags
 }
 
@@ -323,6 +324,9 @@ func ExpandDataEgressSpec(ctx context.Context, m *DataEgressSpecModel) (*control
 	}
 	if v := modelconv.ObjectToMessageWithDiags(ctx, m.Azure, ExpandDataEgressSpecAzure, &diags); v != nil {
 		out.SetAzure(v)
+	}
+	if v := modelconv.ObjectToMessageWithDiags(ctx, m.GCP, ExpandDataEgressSpecGCP, &diags); v != nil {
+		out.SetGcp(v)
 	}
 	return out, diags
 }
@@ -375,6 +379,33 @@ func ExpandDataEgressSpecAzure(_ context.Context, m *DataEgressSpecAzureModel) (
 	out := &controlplanev1.Network_EgressSpec_Azure{
 		FirewallPrivateIp: m.FirewallPrivateIp.ValueString(),
 		HubVnetId:         m.HubVnetID.ValueString(),
+	}
+	return out, diags
+}
+
+// FlattenDataEgressSpecGCP converts a single proto controlplanev1.Network_EgressSpec_GCP into the
+// corresponding nested model. The prev *DataEgressSpecGCPModel arg carries forward
+// TF-only / sensitive / write-only fields and resolves the proto3
+// null-vs-empty ambiguity for Optional-only scalar leaves (Required leaves
+// flatten directly); pass nil when no prior nested state is available.
+func FlattenDataEgressSpecGCP(_ context.Context, proto *controlplanev1.Network_EgressSpec_GCP, prev *DataEgressSpecGCPModel) (DataEgressSpecGCPModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	_ = prev
+	m := DataEgressSpecGCPModel{}
+	m.HubVPCName = types.StringValue(proto.GetHubVpcName())
+	m.HubVPCProject = types.StringValue(proto.GetHubVpcProject())
+	return m, diags
+}
+
+// ExpandDataEgressSpecGCP renders a nested model back into the proto type.
+func ExpandDataEgressSpecGCP(_ context.Context, m *DataEgressSpecGCPModel) (*controlplanev1.Network_EgressSpec_GCP, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if m == nil {
+		return nil, diags
+	}
+	out := &controlplanev1.Network_EgressSpec_GCP{
+		HubVpcName:    m.HubVPCName.ValueString(),
+		HubVpcProject: m.HubVPCProject.ValueString(),
 	}
 	return out, diags
 }

--- a/redpanda/models/network/data_model_gen.go
+++ b/redpanda/models/network/data_model_gen.go
@@ -111,6 +111,7 @@ type DataCustomerManagedResourcesGCPManagementBucketModel struct {
 type DataEgressSpecModel struct {
 	AWS   types.Object `tfsdk:"aws"`
 	Azure types.Object `tfsdk:"azure"`
+	GCP   types.Object `tfsdk:"gcp"`
 }
 
 // DataEgressSpecAWSModel mirrors the nested "egress_spec.aws" attribute. Use the As/To
@@ -126,6 +127,14 @@ type DataEgressSpecAWSModel struct {
 type DataEgressSpecAzureModel struct {
 	FirewallPrivateIp types.String `tfsdk:"firewall_private_ip"`
 	HubVnetID         types.String `tfsdk:"hub_vnet_id"`
+}
+
+// DataEgressSpecGCPModel mirrors the nested "egress_spec.gcp" attribute. Use the As/To
+// converters on the parent struct to move between types.Object and this
+// typed form.
+type DataEgressSpecGCPModel struct {
+	HubVPCName    types.String `tfsdk:"hub_vpc_name"`
+	HubVPCProject types.String `tfsdk:"hub_vpc_project"`
 }
 
 // --- AttrType tables for nested types (consumed by types.ObjectValueFrom / ObjectNull) ---
@@ -206,6 +215,7 @@ func DataEgressSpecAttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
 		"aws":   types.ObjectType{AttrTypes: DataEgressSpecAWSAttrTypes()},
 		"azure": types.ObjectType{AttrTypes: DataEgressSpecAzureAttrTypes()},
+		"gcp":   types.ObjectType{AttrTypes: DataEgressSpecGCPAttrTypes()},
 	}
 }
 
@@ -223,6 +233,15 @@ func DataEgressSpecAzureAttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
 		"firewall_private_ip": types.StringType,
 		"hub_vnet_id":         types.StringType,
+	}
+}
+
+// DataEgressSpecGCPAttrTypes returns the attr.Type map for the "egress_spec.gcp" nested
+// attribute.
+func DataEgressSpecGCPAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"hub_vpc_name":    types.StringType,
+		"hub_vpc_project": types.StringType,
 	}
 }
 
@@ -454,4 +473,24 @@ func DataEgressSpecAzureToObject(ctx context.Context, v *DataEgressSpecAzureMode
 		return types.ObjectNull(DataEgressSpecAzureAttrTypes()), nil
 	}
 	return types.ObjectValueFrom(ctx, DataEgressSpecAzureAttrTypes(), v)
+}
+
+// DecodeDataEgressSpecGCP decodes the sub-field from its parent typed struct.
+// Returns (nil, nil) when the field is null or unknown.
+func DecodeDataEgressSpecGCP(ctx context.Context, v *DataEgressSpecModel) (*DataEgressSpecGCPModel, diag.Diagnostics) {
+	if v == nil || v.GCP.IsNull() || v.GCP.IsUnknown() {
+		return nil, nil
+	}
+	var out DataEgressSpecGCPModel
+	d := v.GCP.As(ctx, &out, basetypes.ObjectAsOptions{})
+	return &out, d
+}
+
+// DataEgressSpecGCPToObject encodes a typed struct back into types.Object.
+// A nil receiver returns types.ObjectNull with the correct attribute types.
+func DataEgressSpecGCPToObject(ctx context.Context, v *DataEgressSpecGCPModel) (types.Object, diag.Diagnostics) {
+	if v == nil {
+		return types.ObjectNull(DataEgressSpecGCPAttrTypes()), nil
+	}
+	return types.ObjectValueFrom(ctx, DataEgressSpecGCPAttrTypes(), v)
 }

--- a/redpanda/models/network/resource_model_gen.go
+++ b/redpanda/models/network/resource_model_gen.go
@@ -113,6 +113,7 @@ type CustomerManagedResourcesGCPManagementBucketModel struct {
 type EgressSpecModel struct {
 	AWS   types.Object `tfsdk:"aws"`
 	Azure types.Object `tfsdk:"azure"`
+	GCP   types.Object `tfsdk:"gcp"`
 }
 
 // EgressSpecAWSModel mirrors the nested "egress_spec.aws" attribute. Use the As/To
@@ -128,6 +129,14 @@ type EgressSpecAWSModel struct {
 type EgressSpecAzureModel struct {
 	FirewallPrivateIp types.String `tfsdk:"firewall_private_ip"`
 	HubVnetID         types.String `tfsdk:"hub_vnet_id"`
+}
+
+// EgressSpecGCPModel mirrors the nested "egress_spec.gcp" attribute. Use the As/To
+// converters on the parent struct to move between types.Object and this
+// typed form.
+type EgressSpecGCPModel struct {
+	HubVPCName    types.String `tfsdk:"hub_vpc_name"`
+	HubVPCProject types.String `tfsdk:"hub_vpc_project"`
 }
 
 // --- AttrType tables for nested types (consumed by types.ObjectValueFrom / ObjectNull) ---
@@ -208,6 +217,7 @@ func EgressSpecAttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
 		"aws":   types.ObjectType{AttrTypes: EgressSpecAWSAttrTypes()},
 		"azure": types.ObjectType{AttrTypes: EgressSpecAzureAttrTypes()},
+		"gcp":   types.ObjectType{AttrTypes: EgressSpecGCPAttrTypes()},
 	}
 }
 
@@ -225,6 +235,15 @@ func EgressSpecAzureAttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
 		"firewall_private_ip": types.StringType,
 		"hub_vnet_id":         types.StringType,
+	}
+}
+
+// EgressSpecGCPAttrTypes returns the attr.Type map for the "egress_spec.gcp" nested
+// attribute.
+func EgressSpecGCPAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"hub_vpc_name":    types.StringType,
+		"hub_vpc_project": types.StringType,
 	}
 }
 
@@ -456,6 +475,26 @@ func EgressSpecAzureToObject(ctx context.Context, v *EgressSpecAzureModel) (type
 		return types.ObjectNull(EgressSpecAzureAttrTypes()), nil
 	}
 	return types.ObjectValueFrom(ctx, EgressSpecAzureAttrTypes(), v)
+}
+
+// DecodeEgressSpecGCP decodes the sub-field from its parent typed struct.
+// Returns (nil, nil) when the field is null or unknown.
+func DecodeEgressSpecGCP(ctx context.Context, v *EgressSpecModel) (*EgressSpecGCPModel, diag.Diagnostics) {
+	if v == nil || v.GCP.IsNull() || v.GCP.IsUnknown() {
+		return nil, nil
+	}
+	var out EgressSpecGCPModel
+	d := v.GCP.As(ctx, &out, basetypes.ObjectAsOptions{})
+	return &out, d
+}
+
+// EgressSpecGCPToObject encodes a typed struct back into types.Object.
+// A nil receiver returns types.ObjectNull with the correct attribute types.
+func EgressSpecGCPToObject(ctx context.Context, v *EgressSpecGCPModel) (types.Object, diag.Diagnostics) {
+	if v == nil {
+		return types.ObjectNull(EgressSpecGCPAttrTypes()), nil
+	}
+	return types.ObjectValueFrom(ctx, EgressSpecGCPAttrTypes(), v)
 }
 
 // GenerateMinimalResourceModel returns a *ResourceModel populated only with

--- a/redpanda/resources/network/integration_network_test.go
+++ b/redpanda/resources/network/integration_network_test.go
@@ -799,6 +799,107 @@ func TestIntegration_Network_RequiresReplace_AzureHubEgress(t *testing.T) {
 	})
 }
 
+// hubEgressGCPConfig builds a GCP network variant with a VPC Hub egress_spec.
+func hubEgressGCPConfig(name, hubProject, hubName string) string {
+	return fmt.Sprintf(`
+provider "redpanda" {}
+
+resource "redpanda_resource_group" "test" {
+  name = "tfrp-mock-net-rg"
+}
+
+resource "redpanda_network" "test" {
+  name              = %q
+  resource_group_id = redpanda_resource_group.test.id
+  cloud_provider    = "gcp"
+  region            = "us-central1"
+  cluster_type      = "dedicated"
+  cidr_block        = "10.0.0.0/20"
+  egress_spec = {
+    gcp = {
+      hub_vpc_project = %q
+      hub_vpc_name    = %q
+    }
+  }
+}
+`, name, hubProject, hubName)
+}
+
+// TestIntegration_Network_CreateAndRefresh_GCPHubEgress validates the Create +
+// no-op cycle for the GCP VPC Hub egress_spec variant.
+func TestIntegration_Network_CreateAndRefresh_GCPHubEgress(t *testing.T) {
+	_, factories := integration.Setup(t)
+
+	const (
+		name       = "tfrp-mock-net-hub-create"
+		hubProject = "tfrp-hub-proj"
+		hubName    = "tfrp-hub-vpc"
+	)
+	cfg := hubEgressGCPConfig(name, hubProject, hubName)
+
+	idPreserved := statecheck.CompareValue(compare.ValuesSame())
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: factories,
+		Steps: []resource.TestStep{
+			integration.CreateStep(networkAddr, cfg, []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(networkAddr, tfjsonpath.New("name"), knownvalue.StringExact(name)),
+				statecheck.ExpectKnownValue(networkAddr,
+					tfjsonpath.New("egress_spec").AtMapKey("gcp").AtMapKey("hub_vpc_project"),
+					knownvalue.StringExact(hubProject)),
+				statecheck.ExpectKnownValue(networkAddr,
+					tfjsonpath.New("egress_spec").AtMapKey("gcp").AtMapKey("hub_vpc_name"),
+					knownvalue.StringExact(hubName)),
+				statecheck.ExpectKnownValue(networkAddr, tfjsonpath.New("id"), knownvalue.NotNull()),
+				idPreserved.AddStateValue(networkAddr, tfjsonpath.New("id")),
+			}),
+			integration.NoopReapplyStep(networkAddr, cfg, []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(networkAddr,
+					tfjsonpath.New("egress_spec").AtMapKey("gcp").AtMapKey("hub_vpc_project"),
+					knownvalue.StringExact(hubProject)),
+				statecheck.ExpectKnownValue(networkAddr, tfjsonpath.New("id"), knownvalue.NotNull()),
+				idPreserved.AddStateValue(networkAddr, tfjsonpath.New("id")),
+			}),
+		},
+	})
+}
+
+// TestIntegration_Network_RequiresReplace_GCPHubEgress mutates
+// egress_spec.gcp.hub_vpc_name and asserts DestroyBeforeCreate.
+// egress_spec.gcp carries RequiresReplace since Network has no Update RPC.
+func TestIntegration_Network_RequiresReplace_GCPHubEgress(t *testing.T) {
+	_, factories := integration.Setup(t)
+
+	const (
+		name       = "tfrp-mock-net-rr-hub"
+		hubProject = "tfrp-hub-proj"
+		hubNameA   = "tfrp-hub-vpc-a"
+		hubNameB   = "tfrp-hub-vpc-b"
+	)
+
+	idChanged := statecheck.CompareValue(compare.ValuesDiffer())
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: factories,
+		Steps: []resource.TestStep{
+			integration.CreateStep(networkAddr, hubEgressGCPConfig(name, hubProject, hubNameA), []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(networkAddr,
+					tfjsonpath.New("egress_spec").AtMapKey("gcp").AtMapKey("hub_vpc_name"),
+					knownvalue.StringExact(hubNameA)),
+				statecheck.ExpectKnownValue(networkAddr, tfjsonpath.New("id"), knownvalue.NotNull()),
+				idChanged.AddStateValue(networkAddr, tfjsonpath.New("id")),
+			}),
+			integration.RequiresReplaceStep(networkAddr, hubEgressGCPConfig(name, hubProject, hubNameB), []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(networkAddr,
+					tfjsonpath.New("egress_spec").AtMapKey("gcp").AtMapKey("hub_vpc_name"),
+					knownvalue.StringExact(hubNameB)),
+				statecheck.ExpectKnownValue(networkAddr, tfjsonpath.New("id"), knownvalue.NotNull()),
+				idChanged.AddStateValue(networkAddr, tfjsonpath.New("id")),
+			}),
+		},
+	})
+}
+
 // TestIntegration_Network_ImportRoundTrip exercises the bearer-id import path.
 // Network's ImportState uses ImportStatePassthroughID on the "id" attribute,
 // so the import id is the xid-like string assigned at Create. Network's

--- a/redpanda/resources/network/schema.yaml
+++ b/redpanda/resources/network/schema.yaml
@@ -115,7 +115,20 @@ egress_spec:
           required: true
           validator: TransitGatewayID
     gcp:
-      todo: true
+      optional: true
+      computed: false
+      plan_modifiers: [RequiresReplace]
+      fields:
+        hub_vpc_project:
+          required: true
+          validator:
+            - GCPResourceName
+            - "LengthAtMost{n: 30}"
+        hub_vpc_name:
+          required: true
+          validator:
+            - GCPResourceName
+            - "LengthAtMost{n: 63}"
     azure:
       optional: true
       computed: false

--- a/redpanda/resources/network/schema_datasource.yaml
+++ b/redpanda/resources/network/schema_datasource.yaml
@@ -64,7 +64,9 @@ egress_spec:
       fields:
         transit_gateway_id: {}
     gcp:
-      todo: true
+      fields:
+        hub_vpc_project: {}
+        hub_vpc_name: {}
     azure:
       fields:
         hub_vnet_id: {}

--- a/redpanda/resources/network/schema_datasource_gen.go
+++ b/redpanda/resources/network/schema_datasource_gen.go
@@ -163,6 +163,20 @@ func DatasourceNetworkSchema(_ context.Context) schema.Schema {
 							},
 						},
 					},
+					"gcp": schema.SingleNestedAttribute{
+						Description: "GCP configuration",
+						Computed:    true,
+						Attributes: map[string]schema.Attribute{
+							"hub_vpc_name": schema.StringAttribute{
+								Description: "Hub VPC Name",
+								Computed:    true,
+							},
+							"hub_vpc_project": schema.StringAttribute{
+								Description: "Hub VPC Project",
+								Computed:    true,
+							},
+						},
+					},
 				},
 			},
 

--- a/redpanda/resources/network/schema_resource_gen.go
+++ b/redpanda/resources/network/schema_resource_gen.go
@@ -201,6 +201,29 @@ func ResourceNetworkSchema(ctx context.Context) schema.Schema {
 							},
 						},
 					},
+					"gcp": schema.SingleNestedAttribute{
+						Description:   "GCP configuration",
+						Optional:      true,
+						PlanModifiers: []planmodifier.Object{objectplanmodifier.RequiresReplace()},
+						Attributes: map[string]schema.Attribute{
+							"hub_vpc_name": schema.StringAttribute{
+								Description: "Hub VPC Name. Length must be at least 1.",
+								Required:    true,
+								Validators: []validator.String{stringvalidator.RegexMatches(
+									regexp.MustCompile(`^[a-z]([-a-z0-9]*[a-z0-9])?$`),
+									"must start with a lowercase letter and can only contain lowercase letters, numbers, and hyphens, and must end with a letter or number",
+								), stringvalidator.LengthAtMost(63)},
+							},
+							"hub_vpc_project": schema.StringAttribute{
+								Description: "Hub VPC Project. Length must be at least 1.",
+								Required:    true,
+								Validators: []validator.String{stringvalidator.RegexMatches(
+									regexp.MustCompile(`^[a-z]([-a-z0-9]*[a-z0-9])?$`),
+									"must start with a lowercase letter and can only contain lowercase letters, numbers, and hyphens, and must end with a letter or number",
+								), stringvalidator.LengthAtMost(30)},
+							},
+						},
+					},
 				},
 			},
 

--- a/redpanda/resources/testdata/network_datasource_schema.golden
+++ b/redpanda/resources/testdata/network_datasource_schema.golden
@@ -89,6 +89,16 @@ attributes:
             - name: hub_vnet_id
               type: StringAttribute
               computed: true
+        - name: gcp
+          type: SingleNestedAttribute
+          computed: true
+          attributes:
+            - name: hub_vpc_name
+              type: StringAttribute
+              computed: true
+            - name: hub_vpc_project
+              type: StringAttribute
+              computed: true
     - name: id
       type: StringAttribute
       required: true

--- a/redpanda/resources/testdata/network_resource_schema.golden
+++ b/redpanda/resources/testdata/network_resource_schema.golden
@@ -116,6 +116,24 @@ attributes:
             - name: hub_vnet_id
               type: StringAttribute
               required: true
+        - name: gcp
+          type: SingleNestedAttribute
+          optional: true
+          plan_modifiers:
+            - objectplanmodifier.requiresReplaceIfModifier
+          attributes:
+            - name: hub_vpc_name
+              type: StringAttribute
+              required: true
+              validators:
+                - stringvalidator.regexMatchesValidator
+                - stringvalidator.lengthAtMostValidator
+            - name: hub_vpc_project
+              type: StringAttribute
+              required: true
+              validators:
+                - stringvalidator.regexMatchesValidator
+                - stringvalidator.lengthAtMostValidator
     - name: id
       type: StringAttribute
       computed: true


### PR DESCRIPTION
Summary

Adds GCP VPC Hub egress support to redpanda_network via a new egress_spec.gcp block, wiring hub_vpc_project and hub_vpc_name. This lets BYOC clusters route outbound internet traffic through a customer-managed hub VPC via cross-project VNet peering, instead of provisioning a per-network Cloud Router / Cloud NAT:

- hub_vpc_project — GCP project ID of the customer's hub/egress VPC (a different project from the spoke, hence a separate field rather than GCP Shared VPC)
- hub_vpc_name — name of the hub VPC network within that project

Redpanda creates a one-sided peering from the spoke VPC to the hub with import_custom_routes=true; the customer must create the mirror peering back with export_custom_routes=true for the default route to actually propagate — otherwise the peering stays inactive and the spoke has no egress. This is a customer-side obligation, not something the provider can enforce.

Both fields are required together and the block is RequiresReplace, since redpanda_network has no Update RPC and egress_spec is immutable at the API descriptor level.

This is the GCP arm of the egress_spec oneof; sibling PRs cover AWS (transit_gateway_id) and Azure (hub_vnet_id/firewall_private_ip). The aws/azure arms remain todo: true on this branch.

```
resource "redpanda_network" "example" {
  name              = "example"
  cloud_provider    = "gcp"
  region            = "us-central1"
  cluster_type      = "byoc"
  egress_spec = {
    gcp = {
      hub_vpc_project = "customer-hub-project"
      hub_vpc_name    = "customer-hub-vpc"
    }
  }
}
```
Notes for reviewers

- Reused the existing GCPResourceName + LengthAtMost validators already applied to the sibling customer_managed_resources.gcp.network_name/network_project_id fields, for consistency — the backend proto itself only enforces min_len=1 on these two fields, so this is stricter than the API requires, but matches the established convention for GCP identifier fields elsewhere in this same schema.
- Fixed NetworkFake.CreateNetwork (in/network.go), which wasn't copyingEgressSpec into stored state — it would have round-tripped as null on Read in the mock-baintegration tests.
- redpanda/resources/network/{schema,schema_datasource}.yaml are the only hand-edited sch*_gen.go, golden files, and docs are
                                                                                         Test plan
                                                                                         - [x] task test:unit
- [x] task test:integration (new TestIntegration_Network_CreateAndRefresh_GCPHubEgress / TestIntegration_Network_RequiresRepla existing suite passing)
- [x] task lint — 0 issues                                                                          
- [x] task docs — regenerated, diff c
- [ ] Live acc test against a real GCP BYOC network 