### PR TITLE
Update redpanda terraform provider to support hub_vnet_id firewall_private_ip (Azure)

### DIFF
--- a/docs/data-sources/network.md
+++ b/docs/data-sources/network.md
@@ -22,6 +22,7 @@ Data source for a Redpanda Cloud network
 - `cloud_provider` (String) Cloud provider where resources are created.
 - `cluster_type` (String) Cluster type. Type is immutable and can only be set on cluster creation.
 - `customer_managed_resources` (Attributes) Cloud resources created by user. (see [below for nested schema](#nestedatt--customer_managed_resources))
+- `egress_spec` (Attributes) Egress Spec configuration (see [below for nested schema](#nestedatt--egress_spec))
 - `name` (String) The unique name of the network.
 - `region` (String) Region where network is placed.
 - `resource_group_id` (String) Resource group ID of the network
@@ -94,6 +95,24 @@ Read-Only:
 Required:
 
 - `name` (String) Name of GCP storage bucket. See the official [GCP documentation](https://cloud.google.com/storage/docs/buckets#naming) for naming restrictions.
+
+
+
+
+<a id="nestedatt--egress_spec"></a>
+### Nested Schema for `egress_spec`
+
+Read-Only:
+
+- `azure` (Attributes) Azure configuration (see [below for nested schema](#nestedatt--egress_spec--azure))
+
+<a id="nestedatt--egress_spec--azure"></a>
+### Nested Schema for `egress_spec.azure`
+
+Read-Only:
+
+- `firewall_private_ip` (String) Firewall Private Ip
+- `hub_vnet_id` (String) Hub Vnet ID
 
 ## Usage
 

--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -26,6 +26,7 @@ Creates a network in the Redpanda Cloud.
 
 - `cidr_block` (String) Network CIDR from where public and private subnets are derived. At least a 21 bits CIDR is required.
 - `customer_managed_resources` (Attributes) Cloud resources created by user. (see [below for nested schema](#nestedatt--customer_managed_resources))
+- `egress_spec` (Attributes) Egress Spec configuration (see [below for nested schema](#nestedatt--egress_spec))
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 
 ### Read-Only
@@ -101,6 +102,23 @@ Required:
 
 - `name` (String) Name of GCP storage bucket. See the official [GCP documentation](https://cloud.google.com/storage/docs/buckets#naming) for naming restrictions. Length must be between 3 and 63. Must match pattern `^[a-z]([-_a-z0-9]*[a-z0-9])?$`.
 
+
+
+
+<a id="nestedatt--egress_spec"></a>
+### Nested Schema for `egress_spec`
+
+Optional:
+
+- `azure` (Attributes) Azure configuration (see [below for nested schema](#nestedatt--egress_spec--azure))
+
+<a id="nestedatt--egress_spec--azure"></a>
+### Nested Schema for `egress_spec.azure`
+
+Required:
+
+- `firewall_private_ip` (String) Firewall Private Ip. Must be a valid IP address.
+- `hub_vnet_id` (String) Hub Vnet ID. Length must be at least 1.
 
 
 

--- a/internal/schemagen/validators.go
+++ b/internal/schemagen/validators.go
@@ -194,6 +194,11 @@ var validatorRegistry = map[string]ValidatorDef{
 		Imports:  []string{validatorsImport},
 		AttrType: "String",
 	},
+	"IPAddress": {
+		Expr:     "validators.IPAddressValidator{}",
+		Imports:  []string{validatorsImport},
+		AttrType: "String",
+	},
 	"OneOf": {
 		Parameterized: true,
 		GenFunc: func(_ string, params map[string]string) (string, []string) {

--- a/internal/testutil/mock/fakes/network.go
+++ b/internal/testutil/mock/fakes/network.go
@@ -68,6 +68,7 @@ func (f *NetworkFake) CreateNetwork(_ context.Context, req *controlplanev1.Creat
 		CidrBlock:                in.GetCidrBlock(),
 		ClusterType:              in.GetClusterType(),
 		CustomerManagedResources: in.GetCustomerManagedResources(),
+		EgressSpec:               in.GetEgressSpec(),
 		State:                    controlplanev1.Network_STATE_READY,
 		CreatedAt:                now,
 		UpdatedAt:                now,

--- a/redpanda/models/network/conv_gen.go
+++ b/redpanda/models/network/conv_gen.go
@@ -31,6 +31,7 @@ type NetworkResponse interface {
 	GetCloudProvider() controlplanev1.CloudProvider
 	GetClusterType() controlplanev1.Cluster_Type
 	GetCustomerManagedResources() *controlplanev1.Network_CustomerManagedResources
+	GetEgressSpec() *controlplanev1.Network_EgressSpec
 	GetId() string
 	GetName() string
 	GetRegion() string
@@ -53,6 +54,7 @@ func Flatten(ctx context.Context, proto NetworkResponse, prev *ResourceModel) (*
 	m.ResourceGroupID = types.StringValue(proto.GetResourceGroupId())
 	m.CidrBlock = cidrBlockFromProto(proto)
 	m.CustomerManagedResources = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetCustomerManagedResources(), func() *CustomerManagedResourcesModel { v, _ := prev.AsCustomerManagedResources(ctx); return v }(), CustomerManagedResourcesAttrTypes(), FlattenCustomerManagedResources, &diags)
+	m.EgressSpec = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetEgressSpec(), func() *EgressSpecModel { v, _ := prev.AsEgressSpec(ctx); return v }(), EgressSpecAttrTypes(), FlattenEgressSpec, &diags)
 	m.ID = types.StringValue(proto.GetId())
 	m.State = types.StringValue(enums.NetworkStateToString(proto.GetState()))
 	m.Zones = modelconv.ListFromSliceWithDiags(ctx, proto.GetZones(), types.StringType, &diags)
@@ -74,6 +76,7 @@ func ExpandCreate(ctx context.Context, m *ResourceModel) (*controlplanev1.Create
 		ResourceGroupId:          m.ResourceGroupID.ValueString(),
 		CidrBlock:                m.CidrBlock.ValueString(),
 		CustomerManagedResources: modelconv.ObjectToMessageWithDiags(ctx, m.CustomerManagedResources, ExpandCustomerManagedResources, &diags),
+		EgressSpec:               modelconv.ObjectToMessageWithDiags(ctx, m.EgressSpec, ExpandEgressSpec, &diags),
 	}
 	req := &controlplanev1.CreateNetworkRequest{
 		Network: payload,
@@ -323,6 +326,59 @@ func ExpandCustomerManagedResourcesGCPManagementBucket(_ context.Context, m *Cus
 	}
 	out := &controlplanev1.CustomerManagedGoogleCloudStorageBucket{
 		Name: m.Name.ValueString(),
+	}
+	return out, diags
+}
+
+// FlattenEgressSpec converts a single proto controlplanev1.Network_EgressSpec into the
+// corresponding nested model. The prev *EgressSpecModel arg carries forward
+// TF-only / sensitive / write-only fields and resolves the proto3
+// null-vs-empty ambiguity for Optional-only scalar leaves (Required leaves
+// flatten directly); pass nil when no prior nested state is available.
+func FlattenEgressSpec(ctx context.Context, proto *controlplanev1.Network_EgressSpec, prev *EgressSpecModel) (EgressSpecModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	_ = prev
+	m := EgressSpecModel{}
+	m.Azure = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetAzure(), func() *EgressSpecAzureModel { v, _ := DecodeEgressSpecAzure(ctx, prev); return v }(), EgressSpecAzureAttrTypes(), FlattenEgressSpecAzure, &diags)
+	return m, diags
+}
+
+// ExpandEgressSpec renders a nested model back into the proto type.
+func ExpandEgressSpec(ctx context.Context, m *EgressSpecModel) (*controlplanev1.Network_EgressSpec, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if m == nil {
+		return nil, diags
+	}
+	out := &controlplanev1.Network_EgressSpec{}
+	if v := modelconv.ObjectToMessageWithDiags(ctx, m.Azure, ExpandEgressSpecAzure, &diags); v != nil {
+		out.SetAzure(v)
+	}
+	return out, diags
+}
+
+// FlattenEgressSpecAzure converts a single proto controlplanev1.Network_EgressSpec_Azure into the
+// corresponding nested model. The prev *EgressSpecAzureModel arg carries forward
+// TF-only / sensitive / write-only fields and resolves the proto3
+// null-vs-empty ambiguity for Optional-only scalar leaves (Required leaves
+// flatten directly); pass nil when no prior nested state is available.
+func FlattenEgressSpecAzure(_ context.Context, proto *controlplanev1.Network_EgressSpec_Azure, prev *EgressSpecAzureModel) (EgressSpecAzureModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	_ = prev
+	m := EgressSpecAzureModel{}
+	m.FirewallPrivateIp = types.StringValue(proto.GetFirewallPrivateIp())
+	m.HubVnetID = types.StringValue(proto.GetHubVnetId())
+	return m, diags
+}
+
+// ExpandEgressSpecAzure renders a nested model back into the proto type.
+func ExpandEgressSpecAzure(_ context.Context, m *EgressSpecAzureModel) (*controlplanev1.Network_EgressSpec_Azure, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if m == nil {
+		return nil, diags
+	}
+	out := &controlplanev1.Network_EgressSpec_Azure{
+		FirewallPrivateIp: m.FirewallPrivateIp.ValueString(),
+		HubVnetId:         m.HubVnetID.ValueString(),
 	}
 	return out, diags
 }

--- a/redpanda/models/network/data_conv_gen.go
+++ b/redpanda/models/network/data_conv_gen.go
@@ -31,6 +31,7 @@ type DataNetworkResponse interface {
 	GetCloudProvider() controlplanev1.CloudProvider
 	GetClusterType() controlplanev1.Cluster_Type
 	GetCustomerManagedResources() *controlplanev1.Network_CustomerManagedResources
+	GetEgressSpec() *controlplanev1.Network_EgressSpec
 	GetId() string
 	GetName() string
 	GetRegion() string
@@ -51,6 +52,7 @@ func FlattenData(ctx context.Context, proto DataNetworkResponse, prev *DataModel
 	m.CloudProvider = types.StringValue(enums.CloudProviderToString(proto.GetCloudProvider()))
 	m.ClusterType = types.StringValue(enums.ClusterTypeToString(proto.GetClusterType()))
 	m.CustomerManagedResources = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetCustomerManagedResources(), func() *DataCustomerManagedResourcesModel { v, _ := prev.AsCustomerManagedResources(ctx); return v }(), DataCustomerManagedResourcesAttrTypes(), FlattenDataCustomerManagedResources, &diags)
+	m.EgressSpec = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetEgressSpec(), func() *DataEgressSpecModel { v, _ := prev.AsEgressSpec(ctx); return v }(), DataEgressSpecAttrTypes(), FlattenDataEgressSpec, &diags)
 	m.Name = types.StringValue(proto.GetName())
 	m.Region = types.StringValue(proto.GetRegion())
 	m.ResourceGroupID = types.StringValue(proto.GetResourceGroupId())
@@ -291,6 +293,59 @@ func ExpandDataCustomerManagedResourcesGCPManagementBucket(_ context.Context, m 
 	}
 	out := &controlplanev1.CustomerManagedGoogleCloudStorageBucket{
 		Name: m.Name.ValueString(),
+	}
+	return out, diags
+}
+
+// FlattenDataEgressSpec converts a single proto controlplanev1.Network_EgressSpec into the
+// corresponding nested model. The prev *DataEgressSpecModel arg carries forward
+// TF-only / sensitive / write-only fields and resolves the proto3
+// null-vs-empty ambiguity for Optional-only scalar leaves (Required leaves
+// flatten directly); pass nil when no prior nested state is available.
+func FlattenDataEgressSpec(ctx context.Context, proto *controlplanev1.Network_EgressSpec, prev *DataEgressSpecModel) (DataEgressSpecModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	_ = prev
+	m := DataEgressSpecModel{}
+	m.Azure = modelconv.ObjectFromMessageWithDiagsAndPrev(ctx, proto.GetAzure(), func() *DataEgressSpecAzureModel { v, _ := DecodeDataEgressSpecAzure(ctx, prev); return v }(), DataEgressSpecAzureAttrTypes(), FlattenDataEgressSpecAzure, &diags)
+	return m, diags
+}
+
+// ExpandDataEgressSpec renders a nested model back into the proto type.
+func ExpandDataEgressSpec(ctx context.Context, m *DataEgressSpecModel) (*controlplanev1.Network_EgressSpec, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if m == nil {
+		return nil, diags
+	}
+	out := &controlplanev1.Network_EgressSpec{}
+	if v := modelconv.ObjectToMessageWithDiags(ctx, m.Azure, ExpandDataEgressSpecAzure, &diags); v != nil {
+		out.SetAzure(v)
+	}
+	return out, diags
+}
+
+// FlattenDataEgressSpecAzure converts a single proto controlplanev1.Network_EgressSpec_Azure into the
+// corresponding nested model. The prev *DataEgressSpecAzureModel arg carries forward
+// TF-only / sensitive / write-only fields and resolves the proto3
+// null-vs-empty ambiguity for Optional-only scalar leaves (Required leaves
+// flatten directly); pass nil when no prior nested state is available.
+func FlattenDataEgressSpecAzure(_ context.Context, proto *controlplanev1.Network_EgressSpec_Azure, prev *DataEgressSpecAzureModel) (DataEgressSpecAzureModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	_ = prev
+	m := DataEgressSpecAzureModel{}
+	m.FirewallPrivateIp = types.StringValue(proto.GetFirewallPrivateIp())
+	m.HubVnetID = types.StringValue(proto.GetHubVnetId())
+	return m, diags
+}
+
+// ExpandDataEgressSpecAzure renders a nested model back into the proto type.
+func ExpandDataEgressSpecAzure(_ context.Context, m *DataEgressSpecAzureModel) (*controlplanev1.Network_EgressSpec_Azure, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if m == nil {
+		return nil, diags
+	}
+	out := &controlplanev1.Network_EgressSpec_Azure{
+		FirewallPrivateIp: m.FirewallPrivateIp.ValueString(),
+		HubVnetId:         m.HubVnetID.ValueString(),
 	}
 	return out, diags
 }

--- a/redpanda/models/network/data_model_gen.go
+++ b/redpanda/models/network/data_model_gen.go
@@ -32,6 +32,7 @@ type DataModel struct {
 	CloudProvider            types.String `tfsdk:"cloud_provider"`
 	ClusterType              types.String `tfsdk:"cluster_type"`
 	CustomerManagedResources types.Object `tfsdk:"customer_managed_resources"`
+	EgressSpec               types.Object `tfsdk:"egress_spec"`
 	ID                       types.String `tfsdk:"id"`
 	Name                     types.String `tfsdk:"name"`
 	Region                   types.String `tfsdk:"region"`
@@ -102,6 +103,21 @@ type DataCustomerManagedResourcesGCPModel struct {
 // typed form.
 type DataCustomerManagedResourcesGCPManagementBucketModel struct {
 	Name types.String `tfsdk:"name"`
+}
+
+// DataEgressSpecModel mirrors the nested "egress_spec" attribute. Use the As/To
+// converters on the parent struct to move between types.Object and this
+// typed form.
+type DataEgressSpecModel struct {
+	Azure types.Object `tfsdk:"azure"`
+}
+
+// DataEgressSpecAzureModel mirrors the nested "egress_spec.azure" attribute. Use the As/To
+// converters on the parent struct to move between types.Object and this
+// typed form.
+type DataEgressSpecAzureModel struct {
+	FirewallPrivateIp types.String `tfsdk:"firewall_private_ip"`
+	HubVnetID         types.String `tfsdk:"hub_vnet_id"`
 }
 
 // --- AttrType tables for nested types (consumed by types.ObjectValueFrom / ObjectNull) ---
@@ -176,6 +192,23 @@ func DataCustomerManagedResourcesGCPManagementBucketAttrTypes() map[string]attr.
 	}
 }
 
+// DataEgressSpecAttrTypes returns the attr.Type map for the "egress_spec" nested
+// attribute.
+func DataEgressSpecAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"azure": types.ObjectType{AttrTypes: DataEgressSpecAzureAttrTypes()},
+	}
+}
+
+// DataEgressSpecAzureAttrTypes returns the attr.Type map for the "egress_spec.azure" nested
+// attribute.
+func DataEgressSpecAzureAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"firewall_private_ip": types.StringType,
+		"hub_vnet_id":         types.StringType,
+	}
+}
+
 // --- Root-level converters (types.Object ⇄ typed struct ergonomics) ---
 
 // AsCustomerManagedResources converts the root customer_managed_resources attribute from
@@ -199,6 +232,29 @@ func DataCustomerManagedResourcesToObject(ctx context.Context, v *DataCustomerMa
 		return types.ObjectNull(DataCustomerManagedResourcesAttrTypes()), nil
 	}
 	return types.ObjectValueFrom(ctx, DataCustomerManagedResourcesAttrTypes(), v)
+}
+
+// AsEgressSpec converts the root egress_spec attribute from
+// types.Object into its typed form. Returns (nil, nil) when the object is
+// null or unknown. Use this when you want typed field access without
+// manually unpacking .Attributes().
+func (m *DataModel) AsEgressSpec(ctx context.Context) (*DataEgressSpecModel, diag.Diagnostics) {
+	if m == nil || m.EgressSpec.IsNull() || m.EgressSpec.IsUnknown() {
+		return nil, nil
+	}
+	var out DataEgressSpecModel
+	d := m.EgressSpec.As(ctx, &out, basetypes.ObjectAsOptions{})
+	return &out, d
+}
+
+// DataEgressSpecToObject encodes a typed struct back into the
+// types.Object shape expected by the framework. A nil receiver returns
+// types.ObjectNull with the correct attribute types.
+func DataEgressSpecToObject(ctx context.Context, v *DataEgressSpecModel) (types.Object, diag.Diagnostics) {
+	if v == nil {
+		return types.ObjectNull(DataEgressSpecAttrTypes()), nil
+	}
+	return types.ObjectValueFrom(ctx, DataEgressSpecAttrTypes(), v)
 }
 
 // --- Sub-level converters (free-standing Decode*/ToObject for types nested beyond root level) ---
@@ -341,4 +397,24 @@ func DataCustomerManagedResourcesGCPManagementBucketToObject(ctx context.Context
 		return types.ObjectNull(DataCustomerManagedResourcesGCPManagementBucketAttrTypes()), nil
 	}
 	return types.ObjectValueFrom(ctx, DataCustomerManagedResourcesGCPManagementBucketAttrTypes(), v)
+}
+
+// DecodeDataEgressSpecAzure decodes the sub-field from its parent typed struct.
+// Returns (nil, nil) when the field is null or unknown.
+func DecodeDataEgressSpecAzure(ctx context.Context, v *DataEgressSpecModel) (*DataEgressSpecAzureModel, diag.Diagnostics) {
+	if v == nil || v.Azure.IsNull() || v.Azure.IsUnknown() {
+		return nil, nil
+	}
+	var out DataEgressSpecAzureModel
+	d := v.Azure.As(ctx, &out, basetypes.ObjectAsOptions{})
+	return &out, d
+}
+
+// DataEgressSpecAzureToObject encodes a typed struct back into types.Object.
+// A nil receiver returns types.ObjectNull with the correct attribute types.
+func DataEgressSpecAzureToObject(ctx context.Context, v *DataEgressSpecAzureModel) (types.Object, diag.Diagnostics) {
+	if v == nil {
+		return types.ObjectNull(DataEgressSpecAzureAttrTypes()), nil
+	}
+	return types.ObjectValueFrom(ctx, DataEgressSpecAzureAttrTypes(), v)
 }

--- a/redpanda/models/network/resource_model_gen.go
+++ b/redpanda/models/network/resource_model_gen.go
@@ -33,6 +33,7 @@ type ResourceModel struct {
 	CloudProvider            types.String   `tfsdk:"cloud_provider"`
 	ClusterType              types.String   `tfsdk:"cluster_type"`
 	CustomerManagedResources types.Object   `tfsdk:"customer_managed_resources"`
+	EgressSpec               types.Object   `tfsdk:"egress_spec"`
 	ID                       types.String   `tfsdk:"id"`
 	Name                     types.String   `tfsdk:"name"`
 	Region                   types.String   `tfsdk:"region"`
@@ -104,6 +105,21 @@ type CustomerManagedResourcesGCPModel struct {
 // typed form.
 type CustomerManagedResourcesGCPManagementBucketModel struct {
 	Name types.String `tfsdk:"name"`
+}
+
+// EgressSpecModel mirrors the nested "egress_spec" attribute. Use the As/To
+// converters on the parent struct to move between types.Object and this
+// typed form.
+type EgressSpecModel struct {
+	Azure types.Object `tfsdk:"azure"`
+}
+
+// EgressSpecAzureModel mirrors the nested "egress_spec.azure" attribute. Use the As/To
+// converters on the parent struct to move between types.Object and this
+// typed form.
+type EgressSpecAzureModel struct {
+	FirewallPrivateIp types.String `tfsdk:"firewall_private_ip"`
+	HubVnetID         types.String `tfsdk:"hub_vnet_id"`
 }
 
 // --- AttrType tables for nested types (consumed by types.ObjectValueFrom / ObjectNull) ---
@@ -178,6 +194,23 @@ func CustomerManagedResourcesGCPManagementBucketAttrTypes() map[string]attr.Type
 	}
 }
 
+// EgressSpecAttrTypes returns the attr.Type map for the "egress_spec" nested
+// attribute.
+func EgressSpecAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"azure": types.ObjectType{AttrTypes: EgressSpecAzureAttrTypes()},
+	}
+}
+
+// EgressSpecAzureAttrTypes returns the attr.Type map for the "egress_spec.azure" nested
+// attribute.
+func EgressSpecAzureAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"firewall_private_ip": types.StringType,
+		"hub_vnet_id":         types.StringType,
+	}
+}
+
 // --- Root-level converters (types.Object ⇄ typed struct ergonomics) ---
 
 // AsCustomerManagedResources converts the root customer_managed_resources attribute from
@@ -201,6 +234,29 @@ func CustomerManagedResourcesToObject(ctx context.Context, v *CustomerManagedRes
 		return types.ObjectNull(CustomerManagedResourcesAttrTypes()), nil
 	}
 	return types.ObjectValueFrom(ctx, CustomerManagedResourcesAttrTypes(), v)
+}
+
+// AsEgressSpec converts the root egress_spec attribute from
+// types.Object into its typed form. Returns (nil, nil) when the object is
+// null or unknown. Use this when you want typed field access without
+// manually unpacking .Attributes().
+func (m *ResourceModel) AsEgressSpec(ctx context.Context) (*EgressSpecModel, diag.Diagnostics) {
+	if m == nil || m.EgressSpec.IsNull() || m.EgressSpec.IsUnknown() {
+		return nil, nil
+	}
+	var out EgressSpecModel
+	d := m.EgressSpec.As(ctx, &out, basetypes.ObjectAsOptions{})
+	return &out, d
+}
+
+// EgressSpecToObject encodes a typed struct back into the
+// types.Object shape expected by the framework. A nil receiver returns
+// types.ObjectNull with the correct attribute types.
+func EgressSpecToObject(ctx context.Context, v *EgressSpecModel) (types.Object, diag.Diagnostics) {
+	if v == nil {
+		return types.ObjectNull(EgressSpecAttrTypes()), nil
+	}
+	return types.ObjectValueFrom(ctx, EgressSpecAttrTypes(), v)
 }
 
 // --- Sub-level converters (free-standing Decode*/ToObject for types nested beyond root level) ---
@@ -345,6 +401,26 @@ func CustomerManagedResourcesGCPManagementBucketToObject(ctx context.Context, v 
 	return types.ObjectValueFrom(ctx, CustomerManagedResourcesGCPManagementBucketAttrTypes(), v)
 }
 
+// DecodeEgressSpecAzure decodes the sub-field from its parent typed struct.
+// Returns (nil, nil) when the field is null or unknown.
+func DecodeEgressSpecAzure(ctx context.Context, v *EgressSpecModel) (*EgressSpecAzureModel, diag.Diagnostics) {
+	if v == nil || v.Azure.IsNull() || v.Azure.IsUnknown() {
+		return nil, nil
+	}
+	var out EgressSpecAzureModel
+	d := v.Azure.As(ctx, &out, basetypes.ObjectAsOptions{})
+	return &out, d
+}
+
+// EgressSpecAzureToObject encodes a typed struct back into types.Object.
+// A nil receiver returns types.ObjectNull with the correct attribute types.
+func EgressSpecAzureToObject(ctx context.Context, v *EgressSpecAzureModel) (types.Object, diag.Diagnostics) {
+	if v == nil {
+		return types.ObjectNull(EgressSpecAzureAttrTypes()), nil
+	}
+	return types.ObjectValueFrom(ctx, EgressSpecAzureAttrTypes(), v)
+}
+
 // GenerateMinimalResourceModel returns a *ResourceModel populated only with
 // the supplied id + timeouts; every other field is at its typed null (or its
 // declared minimal_default). Used by resources that need to persist a
@@ -355,6 +431,7 @@ func GenerateMinimalResourceModel(id types.String, timeout timeouts.Value) *Reso
 		CloudProvider:            types.StringNull(),
 		ClusterType:              types.StringNull(),
 		CustomerManagedResources: types.ObjectNull(CustomerManagedResourcesAttrTypes()),
+		EgressSpec:               types.ObjectNull(EgressSpecAttrTypes()),
 		ID:                       id,
 		Name:                     types.StringNull(),
 		Region:                   types.StringNull(),

--- a/redpanda/resources/network/integration_network_test.go
+++ b/redpanda/resources/network/integration_network_test.go
@@ -603,6 +603,107 @@ func TestIntegration_Network_RequiresReplace_CMR_GCP(t *testing.T) {
 	})
 }
 
+// hubEgressAzureConfig builds an Azure network variant with a hub-VNet egress_spec.
+func hubEgressAzureConfig(name, hubVnetID, firewallIP string) string {
+	return fmt.Sprintf(`
+provider "redpanda" {}
+
+resource "redpanda_resource_group" "test" {
+  name = "tfrp-mock-net-rg"
+}
+
+resource "redpanda_network" "test" {
+  name              = %q
+  resource_group_id = redpanda_resource_group.test.id
+  cloud_provider    = "azure"
+  region            = "westus2"
+  cluster_type      = "dedicated"
+  cidr_block        = "10.0.0.0/20"
+  egress_spec = {
+    azure = {
+      hub_vnet_id         = %q
+      firewall_private_ip = %q
+    }
+  }
+}
+`, name, hubVnetID, firewallIP)
+}
+
+// TestIntegration_Network_CreateAndRefresh_AzureHubEgress validates the Create +
+// no-op cycle for the Azure hub-VNet egress_spec variant.
+func TestIntegration_Network_CreateAndRefresh_AzureHubEgress(t *testing.T) {
+	_, factories := integration.Setup(t)
+
+	const (
+		name       = "tfrp-mock-net-hub-create"
+		hubVnetID  = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/hub-vnet"
+		firewallIP = "10.1.0.4"
+	)
+	cfg := hubEgressAzureConfig(name, hubVnetID, firewallIP)
+
+	idPreserved := statecheck.CompareValue(compare.ValuesSame())
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: factories,
+		Steps: []resource.TestStep{
+			integration.CreateStep(networkAddr, cfg, []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(networkAddr, tfjsonpath.New("name"), knownvalue.StringExact(name)),
+				statecheck.ExpectKnownValue(networkAddr,
+					tfjsonpath.New("egress_spec").AtMapKey("azure").AtMapKey("hub_vnet_id"),
+					knownvalue.StringExact(hubVnetID)),
+				statecheck.ExpectKnownValue(networkAddr,
+					tfjsonpath.New("egress_spec").AtMapKey("azure").AtMapKey("firewall_private_ip"),
+					knownvalue.StringExact(firewallIP)),
+				statecheck.ExpectKnownValue(networkAddr, tfjsonpath.New("id"), knownvalue.NotNull()),
+				idPreserved.AddStateValue(networkAddr, tfjsonpath.New("id")),
+			}),
+			integration.NoopReapplyStep(networkAddr, cfg, []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(networkAddr,
+					tfjsonpath.New("egress_spec").AtMapKey("azure").AtMapKey("hub_vnet_id"),
+					knownvalue.StringExact(hubVnetID)),
+				statecheck.ExpectKnownValue(networkAddr, tfjsonpath.New("id"), knownvalue.NotNull()),
+				idPreserved.AddStateValue(networkAddr, tfjsonpath.New("id")),
+			}),
+		},
+	})
+}
+
+// TestIntegration_Network_RequiresReplace_AzureHubEgress mutates
+// egress_spec.azure.firewall_private_ip and asserts DestroyBeforeCreate.
+// egress_spec.azure carries RequiresReplace since Network has no Update RPC.
+func TestIntegration_Network_RequiresReplace_AzureHubEgress(t *testing.T) {
+	_, factories := integration.Setup(t)
+
+	const (
+		name        = "tfrp-mock-net-rr-hub"
+		hubVnetID   = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/hub-vnet"
+		firewallIPA = "10.1.0.4"
+		firewallIPB = "10.1.0.5"
+	)
+
+	idChanged := statecheck.CompareValue(compare.ValuesDiffer())
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: factories,
+		Steps: []resource.TestStep{
+			integration.CreateStep(networkAddr, hubEgressAzureConfig(name, hubVnetID, firewallIPA), []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(networkAddr,
+					tfjsonpath.New("egress_spec").AtMapKey("azure").AtMapKey("firewall_private_ip"),
+					knownvalue.StringExact(firewallIPA)),
+				statecheck.ExpectKnownValue(networkAddr, tfjsonpath.New("id"), knownvalue.NotNull()),
+				idChanged.AddStateValue(networkAddr, tfjsonpath.New("id")),
+			}),
+			integration.RequiresReplaceStep(networkAddr, hubEgressAzureConfig(name, hubVnetID, firewallIPB), []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(networkAddr,
+					tfjsonpath.New("egress_spec").AtMapKey("azure").AtMapKey("firewall_private_ip"),
+					knownvalue.StringExact(firewallIPB)),
+				statecheck.ExpectKnownValue(networkAddr, tfjsonpath.New("id"), knownvalue.NotNull()),
+				idChanged.AddStateValue(networkAddr, tfjsonpath.New("id")),
+			}),
+		},
+	})
+}
+
 // TestIntegration_Network_ImportRoundTrip exercises the bearer-id import path.
 // Network's ImportState uses ImportStatePassthroughID on the "id" attribute,
 // so the import id is the xid-like string assigned at Create. Network's

--- a/redpanda/resources/network/schema.yaml
+++ b/redpanda/resources/network/schema.yaml
@@ -103,6 +103,22 @@ zones:
 
 # --- New proto fields (auto-added by schemagen -todo) ---
 egress_spec:
-  todo: true
+  optional: true
+  computed: false
+  fields:
+    aws:
+      todo: true
+    gcp:
+      todo: true
+    azure:
+      optional: true
+      computed: false
+      plan_modifiers: [RequiresReplace]
+      fields:
+        hub_vnet_id:
+          required: true
+        firewall_private_ip:
+          required: true
+          validator: IPAddress
 cloud_provider_access_id:
   todo: true

--- a/redpanda/resources/network/schema_datasource.yaml
+++ b/redpanda/resources/network/schema_datasource.yaml
@@ -59,6 +59,14 @@ customer_managed_resources:
 
 # --- New proto fields (auto-added by schemagen -todo) ---
 egress_spec:
-  todo: true
+  fields:
+    aws:
+      todo: true
+    gcp:
+      todo: true
+    azure:
+      fields:
+        hub_vnet_id: {}
+        firewall_private_ip: {}
 cloud_provider_access_id:
   todo: true

--- a/redpanda/resources/network/schema_datasource_gen.go
+++ b/redpanda/resources/network/schema_datasource_gen.go
@@ -135,6 +135,27 @@ func DatasourceNetworkSchema(_ context.Context) schema.Schema {
 				},
 			},
 
+			"egress_spec": schema.SingleNestedAttribute{
+				Description: "Egress Spec configuration",
+				Computed:    true,
+				Attributes: map[string]schema.Attribute{
+					"azure": schema.SingleNestedAttribute{
+						Description: "Azure configuration",
+						Computed:    true,
+						Attributes: map[string]schema.Attribute{
+							"firewall_private_ip": schema.StringAttribute{
+								Description: "Firewall Private Ip",
+								Computed:    true,
+							},
+							"hub_vnet_id": schema.StringAttribute{
+								Description: "Hub Vnet ID",
+								Computed:    true,
+							},
+						},
+					},
+				},
+			},
+
 			"name": schema.StringAttribute{
 				Description: "The unique name of the network.",
 				Computed:    true,

--- a/redpanda/resources/network/schema_resource_gen.go
+++ b/redpanda/resources/network/schema_resource_gen.go
@@ -166,6 +166,29 @@ func ResourceNetworkSchema(ctx context.Context) schema.Schema {
 				},
 			},
 
+			"egress_spec": schema.SingleNestedAttribute{
+				Description: "Egress Spec configuration",
+				Optional:    true,
+				Attributes: map[string]schema.Attribute{
+					"azure": schema.SingleNestedAttribute{
+						Description:   "Azure configuration",
+						Optional:      true,
+						PlanModifiers: []planmodifier.Object{objectplanmodifier.RequiresReplace()},
+						Attributes: map[string]schema.Attribute{
+							"firewall_private_ip": schema.StringAttribute{
+								Description: "Firewall Private Ip. Must be a valid IP address.",
+								Required:    true,
+								Validators:  []validator.String{validators.IPAddressValidator{}},
+							},
+							"hub_vnet_id": schema.StringAttribute{
+								Description: "Hub Vnet ID. Length must be at least 1.",
+								Required:    true,
+							},
+						},
+					},
+				},
+			},
+
 			"id": schema.StringAttribute{
 				Description:   "Network ID. The ID is an output of the Create Network request and cannot be set by the caller. Must match pattern `^[a-v0-9]{20}`.",
 				Computed:      true,

--- a/redpanda/resources/testdata/network_datasource_schema.golden
+++ b/redpanda/resources/testdata/network_datasource_schema.golden
@@ -68,6 +68,20 @@ attributes:
             - name: network_project_id
               type: StringAttribute
               computed: true
+    - name: egress_spec
+      type: SingleNestedAttribute
+      computed: true
+      attributes:
+        - name: azure
+          type: SingleNestedAttribute
+          computed: true
+          attributes:
+            - name: firewall_private_ip
+              type: StringAttribute
+              computed: true
+            - name: hub_vnet_id
+              type: StringAttribute
+              computed: true
     - name: id
       type: StringAttribute
       required: true

--- a/redpanda/resources/testdata/network_resource_schema.golden
+++ b/redpanda/resources/testdata/network_resource_schema.golden
@@ -87,6 +87,24 @@ attributes:
               validators:
                 - stringvalidator.regexMatchesValidator
                 - stringvalidator.lengthAtMostValidator
+    - name: egress_spec
+      type: SingleNestedAttribute
+      optional: true
+      attributes:
+        - name: azure
+          type: SingleNestedAttribute
+          optional: true
+          plan_modifiers:
+            - objectplanmodifier.requiresReplaceIfModifier
+          attributes:
+            - name: firewall_private_ip
+              type: StringAttribute
+              required: true
+              validators:
+                - validators.IPAddressValidator
+            - name: hub_vnet_id
+              type: StringAttribute
+              required: true
     - name: id
       type: StringAttribute
       computed: true

--- a/redpanda/validators/ip_address.go
+++ b/redpanda/validators/ip_address.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package validators
+
+import (
+	"context"
+	"net"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+var _ validator.String = IPAddressValidator{}
+
+// IPAddressValidator ensures the value parses as a valid IPv4 or IPv6 address
+// literal, mirroring the API's buf.validate (buf.validate.field).string.ip
+// constraint (net.ParseIP semantics — no CIDR suffix).
+type IPAddressValidator struct{}
+
+// Description provides a description of the validator.
+func (IPAddressValidator) Description(_ context.Context) string {
+	return "value must be a valid IPv4 or IPv6 address"
+}
+
+// MarkdownDescription provides a description of the validator in markdown format.
+func (IPAddressValidator) MarkdownDescription(_ context.Context) string {
+	return "value must be a valid IPv4 or IPv6 address"
+}
+
+// ValidateString validates that the string is a parseable IP address.
+func (IPAddressValidator) ValidateString(_ context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	if net.ParseIP(req.ConfigValue.ValueString()) == nil {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Invalid IP Address",
+			"value must be a valid IPv4 or IPv6 address, got: "+req.ConfigValue.ValueString(),
+		)
+	}
+}


### PR DESCRIPTION
Summary

Added Azure hub-egress support to redpanda_network on branch azure (independent, same pattern as AWS/GCP). Research found the mapper's "Azure is a placeholder" comment is stale — Azure hub-egress is actually fully implemented server-side (VNet peering + UDR-to-firewall routing, agent, cloud-ui), gated by the same shared preview flag.


Changes (3 commits, same feat/chore/test split):
- 650015d feat(network): egress_spec.azure.{hub_vnet_id,firewall_private_ip}, both required, RequiresReplace. Added a new IPAddressValidator (net.ParseIP-based, accepts IPv4/IPv6) mirroring the API's buf.validate string.ip constraint — no existing validator in this repo covered IP-literal format, unlike GCP where I could reuse a sibling field's validator. hub_vnet_id got no extra pattern validator (full ARM resource ID, no sibling precedent in this schema, backend itself only enforces non-empty).
- 8a8deeb chore(generate): regenerated schema/model/golden/docs
- e99071e test(network): same NetworkFake.CreateNetwork missing-EgressSpec fix (needed independently on this branch too) + create/refresh and RequiresReplace integration tests

All green: unit tests, lint (0 issues), full integration suite, go build. aws/gcp arms remain todo: true here.

```
resource "redpanda_network" "test" {
  name              = "my-network"
  cloud_provider    = "azure"
  region            = "westus2"
  cluster_type      = "byoc"
  egress_spec = {
    azure = {
      hub_vnet_id         = "/subscriptions/.../resourceGroups/.../providers/Microsoft.Network/virtualNetworks/hub-vnet"
      firewall_private_ip = "10.1.0.4"
    }
  }
}
```

                                                                                             
Notes for reviewers                                                                                   
- Added IPAddressValidator (redpanda/validators/ip_address.go) — net.ParseIP-based, accepts IPv4/IPv6 — mirroring the API's buf.validate stwall_private_ip. No existing validatorin this repo covered bare IP-address format.
- hub_vnet_id has no format validatorull ARM resource ID with no siblingfield in this schema to pattern-match against, and the backend itself only enforces non-empty.
- Fixed NetworkFake.CreateNetwork (in/network.go), which wasn't copyingEgressSpec into stored state — it would have round-tripped as null on Read in the mock-backed integration tests.
- redpanda/resources/network/{schema,schema_datasource}.yaml are the only hand-edited schem*_gen.go, golden files, and docs are

Test plan
- [x] task test:unit
- [x] task test:integration (new TestIntegration_Network_CreateAndRefresh_AzureHubEgress / TestIntegration_Network_RequiresReplall existing suite passing)
- [x] task lint — 0 issues                                                                            - [x] task docs — regenerated, diff c
- [ ] Live acc test against a real Azure BYOC network (gated behind the enable-transit-gateway-egress preview flag server-side; not run her